### PR TITLE
Fix Oinkmaster modifysid with group name - v1.

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -179,6 +179,8 @@ class GroupMatcher(object):
                 return cls(group.strip())
             except:
                 pass
+        if buf.endswith(".rules"):
+            return cls(buf.strip())
         return None
 
 class ReRuleMatcher(object):
@@ -240,7 +242,7 @@ class ModifyRuleFilter(object):
             raise Exception("Bad number of arguments.")
         matcher = parse_rule_match(matchstring)
         if not matcher:
-            raise Exception("Bad match string: %s" % (tokens[0]))
+            raise Exception("Bad match string: %s" % (matchstring))
         pattern = re.compile(a)
 
         # Convert Oinkmaster backticks to Python.
@@ -386,11 +388,11 @@ def parse_rule_match(match):
     if matcher:
         return matcher
 
-    matcher = GroupMatcher.parse(match)
+    matcher = FilenameMatcher.parse(match)
     if matcher:
         return matcher
 
-    matcher = FilenameMatcher.parse(match)
+    matcher = GroupMatcher.parse(match)
     if matcher:
         return matcher
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -305,6 +305,15 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
         rule_out = f.filter(suricata.update.rule.parse(rule_in))
         self.assertEqual(rule_in, rule_out.format())
 
+    def test_oinkmaster_modify_group_name(self):
+        """Test an Oinkmaster style modification line using a group name."""
+        f = main.ModifyRuleFilter.parse(
+            'modifysid botcc.rules "^alert" | "drop"')
+        rule_in ="""alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET MALWARE Windows executable sent when remote host claims to send an image 2"; flow: established,to_client; content:"|0d 0a|Content-Type|3a| image/jpeg|0d 0a 0d 0a|MZ"; fast_pattern:12,20; classtype:trojan-activity; sid:2020757; rev:2;)"""
+        rule = suricata.update.rule.parse(rule_in, "rules/botcc.rules")
+        rule_out = f.filter(rule)
+        self.assertTrue(rule_out.format().startswith("drop"))
+
 class GroupMatcherTestCase(unittest.TestCase):
 
     rule_string = """alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET MALWARE Windows executable sent when remote host claims to send an image 2"; flow: established,from_server; content:"|0d 0a|Content-Type|3a| image/jpeg|0d 0a 0d 0a|MZ"; fast_pattern:12,20; classtype:trojan-activity; sid:2020757; rev:2;)"""


### PR DESCRIPTION
Make the group name matcher the last matcher to be parsed,
and accept the match spec if it ends with .rules and not
prefixed with group.

This was broken while fixing up other issues in group name
parsing to make it more predictable.
