### PR TITLE
github/codeowners: add OISF/core-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,5 @@
 # additionally, it seems only the directoy syntax works.
 # e.g. '/src/source-*.[ch]  @regit' seems to have no effect.
 
-*                   @jasonish
+*                   @jasonish @OISF/core-team
 


### PR DESCRIPTION
Add core team so all PRs get a reviewer assigned. If the PR is by @jasonish it will be just OISF/core-team, otherwise it'll be both. Then @jasonish can approve in name of core-team as well.
