### PR TITLE
cache and permission fixups - 1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,5 +118,5 @@ Files and Directories
   This is a single file that contains all the rules from all input
   files and should be used by Suricata.
 
-``/var/lib/suricata/cache``
+``/var/lib/suricata/rules/.cache``
   Downloaded rule files are cached here.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,13 +35,6 @@ Options
 
    Default: */var/lib/suricata/rules*
 
-.. option:: --cache-dir <directory>
-
-   Directory where files are cached, such as files downloaded from a
-   URL.
-
-   Default: */var/lib/suricata/cache*
-
 .. option:: --suricata=<path>
 
    The path to the Suricata program used to determine which version of

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -899,7 +899,17 @@ def copytree(src, dst):
             dst_path = os.path.join(dst, src_path[len(src) + 1:])
             if not os.path.exists(os.path.dirname(dst_path)):
                 os.makedirs(os.path.dirname(dst_path), mode=0o770)
-            shutil.copy2(src_path, dst_path)
+            shutil.copyfile(src_path, dst_path)
+
+            # Also attempt to copy the stat bits, but this may fail
+            # if the owner of the file is not the same as the user
+            # running the program.
+            try:
+                shutil.copystat(src_path, dst_path)
+            except OSError as err:
+                logger.debug(
+                    "Failed to copy stat info from %s to %s", src_path,
+                    dst_path)
 
 def load_sources(config, suricata_version):
     files = {}

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -983,6 +983,10 @@ def load_sources(config, suricata_version):
 
     return files
 
+def copytree_ignore_backup(src, names):
+    """ Returns files to ignore when doing a backup of the rules. """
+    return [".cache"]
+
 def main():
     global args
 
@@ -1278,7 +1282,7 @@ def main():
     logger.info("Backing up current rules.")
     backup_directory = util.mktempdir()
     shutil.copytree(args.output, os.path.join(
-        backup_directory, "backup"))
+        backup_directory, "backup"), ignore=copytree_ignore_backup)
 
     if not args.no_merge:
         # The default, write out a merged file.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,7 +111,6 @@ class TestRulecat(unittest.TestCase):
                  "file://%s/emerging.rules.tar.gz" % (
                      os.getcwd()),
                  "--local", "./rule-with-unicode.rules",
-                 "--cache-dir", "./tmp",
                  "--force",
                  "--output", "./tmp/rules/",
                  "--yaml-fragment", "./tmp/suricata-rules.yaml",
@@ -151,7 +150,6 @@ class TestRulecat(unittest.TestCase):
                  "file://%s/emerging.rules.tar.gz" % (
                      os.getcwd()),
                  "--local", "./rule-with-unicode.rules",
-                 "--cache-dir", "./tmp",
                  "--force",
                  "--output", "./tmp/rules/",
                  "--yaml-fragment", "./tmp/suricata-rules.yaml",


### PR DESCRIPTION
Fix a permission issue when a subsequent run of suricata-update is done as a different user who doesn't own the rule files, but has group permissions to modify them. Only the file owner can modify all the file stat parameters which is what was being attempted.

Use a subdirectory (.cache) of the rule output directory as the cache so permissions on one less directory need to be dealt with. Skip this directory when doing the rule backup in case the Suricata test fails.
