### PR TITLE
Secret masking - Hide secret codes in log output - v1

### DIFF
--- a/suricata/update/loghandler.py
+++ b/suricata/update/loghandler.py
@@ -18,6 +18,15 @@
 import logging
 import time
 
+# A list of secrets that will be replaced in the log output.
+secrets = {}
+
+def add_secret(secret, replacement):
+    """Register a secret to be masked. The secret will be replaced with:
+           <replacement>
+    """
+    secrets[str(secret)] = str(replacement)
+
 class SuriColourLogHandler(logging.StreamHandler):
     """An alternative stream log handler that logs with Suricata inspired
     log colours."""
@@ -61,5 +70,10 @@ class SuriColourLogHandler(logging.StreamHandler):
             record.levelname.title(),
             self.RESET,
             message_prefix,
-            record.getMessage(),
+            self.mask_secrets(record.getMessage()),
             self.RESET))
+
+    def mask_secrets(self, msg):
+        for secret in secrets:
+            msg = msg.replace(secret, "<%s>" % secrets[secret])
+        return msg

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -45,8 +45,8 @@ if sys.argv[0] == __file__:
 import suricata.update.rule
 import suricata.update.engine
 import suricata.update.net
+import suricata.update.loghandler
 from suricata.update import configs
-from suricata.update.loghandler import SuriColourLogHandler
 from suricata.update import extract
 from suricata.update import util
 
@@ -54,7 +54,7 @@ from suricata.update import util
 if len(logging.root.handlers) == 0 and os.isatty(sys.stderr.fileno()):
     logger = logging.getLogger()
     logger.setLevel(level=logging.INFO)
-    logger.addHandler(SuriColourLogHandler())
+    logger.addHandler(suricata.update.loghandler.SuriColourLogHandler())
 else:
     logging.basicConfig(
         level=logging.INFO,
@@ -950,6 +950,7 @@ def load_sources(config, suricata_version):
                     code = source["code"]
                 else:
                     code = config.get("etpro")
+                suricata.update.loghandler.add_secret(code, "code")
                 if not code:
                     logger.error("ET-Pro source specified without code: %s",
                                  str(source))


### PR DESCRIPTION
Allows secrets to be registered with the logger that will be masked. For now this just means the ET Pro code which is now logged like:

```
28/11/2017 -- 21:22:14 - <Info> -- Checking https://rules.emergingthreatspro.com/<code>/suricata-4.1.0/etpro.rules.tar.gz.md5.
```

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2259