### PR TITLE
source index support - v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ _work
 
 # Development update.yaml
 /update.yaml
+
+# The file containing the git revision.
+/suricata/update/revision.py*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
   assigned to the OISF.
 - Features are derived from idstools-rulecat, but with more
   opinionated defaults.
+- Supports an index of rule sources to aid in discovery of rulesets.

--- a/README.rst
+++ b/README.rst
@@ -119,4 +119,11 @@ Files and Directories
   files and should be used by Suricata.
 
 ``/var/lib/suricata/rules/.cache``
-  Downloaded rule files are cached here.
+  Directory where downloaded rule files are cached here.
+
+``/var/lib/suricata/rules/.cache/index.yaml``
+  Cached copy of the rule source index.
+
+``/var/lib/suricata/update/sources``
+  Configuration direction for sources enabled or added with
+  ``enable-source`` or ``add-source``.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,19 +1,20 @@
+#############################################
 suricata-update - A Suricata rule update tool
-=============================================
+#############################################
 
 Synopsis
---------
+========
 
 ``suricata-update`` [OPTIONS]
 
 Description
------------
+===========
 
 ``suricata-update`` aims to be a simple to use rule download and
 management tool for Suricata.
 
 Options
--------
+=======
 
 .. option:: -h, --help
 
@@ -199,7 +200,7 @@ Options
    Display the version of **suricata-update**.
 
 Rule Matching
--------------
+=============
 
 Matching rules for disabling, enabling, converting to drop or
 modification can be done with the following:
@@ -210,7 +211,7 @@ modification can be done with the following:
 - filename
 
 Signature ID Matching
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 A signature ID can be matched by just its signature ID, for example::
 
@@ -221,7 +222,7 @@ The generator ID can also be used for compatibility with other tools::
     1:1034
 
 Regular Expression Matching
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 Regular expression matching will match a regular expression over the
 complete rule. Example::
@@ -230,7 +231,7 @@ complete rule. Example::
     re:MS(0[7-9]|10)-\d+
 
 Group Matching
-~~~~~~~~~~~~~~
+--------------
 
 The group matcher matches against the group the rule was loaded
 from. Basically this is the filename without the leading path or file
@@ -245,7 +246,7 @@ be used::
   group:*deleted*
 
 Filename Matching
-~~~~~~~~~~~~~~~~~
+-----------------
 
 The filename matcher matches against the filename the rule was loaded
 from taking into consideration the full path. Shell wildcard patterns
@@ -255,7 +256,7 @@ are allowed::
   filename:*/emerging-dos.rules
 
 Modifying Rules
-~~~~~~~~~~~~~~~
+---------------
 
 Rule modification can be done with regular expression search and
 replace. The basic format for a rule modification specifier is::
@@ -273,40 +274,65 @@ Example converting all drop rules with noalert back to alert::
 
   re:. "^drop(.*)noalert(.*)" "alert\\1noalert\\2"  
 
+Sub Commands
+============
+
+add-source - Add a new source by URL
+------------------------------------
+
+Description
+~~~~~~~~~~~
+
+The ``add-source`` adds a source to the set of enabled sources by
+URL. It is useful to add a source that is not provided in the index.
+
+Options
+~~~~~~~
+
+.. option:: --name <name>
+
+   The name of the source. If not provided on the command line the
+   user will be prompted.
+
+.. option:: --url <url>
+
+   The URL of the source. If not provided on the command line the user
+   will be prompted.
+
 Example Configuration Files
----------------------------
+===========================
 
 .. _example_update_yaml:
 
 Example Configuration File (/etc/suricata/update.yaml)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------
 
 .. literalinclude:: ../suricata/update/configs/update.yaml
 
 .. _example-enable-conf:
 
 Example Configuration to Enable Rules (--enable-conf)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 
 .. literalinclude:: ../suricata/update/configs/enable.conf
 
 .. _example-disable-conf:
 
 Example Configuration to Enable Disable (--disable-conf)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------
 
 .. literalinclude:: ../suricata/update/configs/disable.conf
 
 .. _example-drop-conf:
 
 Example Configuration to convert Rules to Drop (--drop-conf)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------------
 
 .. literalinclude:: ../suricata/update/configs/drop.conf
 
 .. _example-modify-conf:
 
 Example Configuration to modify Rules (--modify-conf)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
 
 .. literalinclude:: ../suricata/update/configs/modify.conf

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -145,16 +145,14 @@ Options
 
 .. option:: --etopen
 
-   Download the ET open ruleset. This is the default if ``--url`` or
-   ``--etpro`` are not provided.
+   Download the ET/Open ruleset.
 
-   If one of ``etpro`` or ``--url`` is also specified, this option
-   will at the ET open URL to the list of remote ruleset to be
-   downloaded.
+   This is the default action of no ``--url`` options are provided or
+   no sources are configured.
 
-.. option:: --etpro=<code>
-
-   Download the ET pro ruleset using the provided code.
+   Use this option to enable the ET/Open ruleset in addition to any
+   URLs provided on the command line or sources provided in the
+   configuration.
 
 .. option:: -q, --quiet
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,22 @@
+import subprocess
 from setuptools import setup
 
-import suricata.update
+from suricata.update.version import version
+
+def write_revision():
+    try:
+        revision = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"])
+        with open("./suricata/update/revision.py", "w") as fileobj:
+            fileobj.write("revision = '%s'" % (revision.strip()))
+    except Exception as err:
+        print("Failed to get current git revision: %s" % (err))
+
+write_revision()
 
 setup(
     name="suricata-update",
-    version=suricata.update.version,
+    version=version,
     description="Suricata Update Tool",
     author="Jason Ish",
     author_email="ish@unx.ca",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=[
         "suricata",
         "suricata.update",
+        "suricata.update.commands",
         "suricata.update.configs",
         "suricata.update.compat",
         "suricata.update.compat.argparse",

--- a/suricata/update/__init__.py
+++ b/suricata/update/__init__.py
@@ -1,1 +1,0 @@
-version = "1.0.0.dev"

--- a/suricata/update/commands/__init__.py
+++ b/suricata/update/commands/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2017 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from suricata.update.commands import listenabledsources
+from suricata.update.commands import addsource
+from suricata.update.commands import listsources

--- a/suricata/update/commands/addsource.py
+++ b/suricata/update/commands/addsource.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2017 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from __future__ import print_function
+
+import logging
+
+from suricata.update import sources
+
+logger = logging.getLogger()
+
+def register(parser):
+    parser.add_argument("--name", metavar="<name>", help="Name of source")
+    parser.add_argument("--url", metavar="<url>", help="Source URL")
+    parser.set_defaults(func=add_source)
+
+def add_source(config):
+    args = config.args
+
+    if args.name:
+        name = args.name
+    else:
+        while True:
+            name = raw_input("Name of source: ").strip()
+            if name:
+                break
+
+    if sources.source_name_exists(name):
+        logger.error("A source with name %s already exists.", name)
+        return 1
+
+    if args.url:
+        url = args.url
+    else:
+        while True:
+            url = raw_input("URL: ").strip()
+            if url:
+                break
+
+    source_config = sources.SourceConfiguration(name, url=url)
+    sources.save_source_config(source_config)

--- a/suricata/update/commands/listenabledsources.py
+++ b/suricata/update/commands/listenabledsources.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2017 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from __future__ import print_function
+
+import logging
+
+from suricata.update import sources
+
+logger = logging.getLogger()
+
+def register(parser):
+    parser.set_defaults(func=list_enabled_sources)
+
+def list_enabled_sources(config):
+
+    found = False
+
+    # First list sources from the main config.
+    config_sources = config.get("sources")
+    if config_sources:
+        found = True
+        print("From %s:" % (config.filename))
+        for source in config_sources:
+            print("  - %s" % (source))
+
+    # And local files.
+    local = config.get("local")
+    if local:
+        found = True
+        print("Local files/directories:")
+        for filename in local:
+            print("  - %s" % (filename))
+
+    enabled_sources = sources.get_enabled_sources()
+    if enabled_sources:
+        found = True
+        print("Enabled sources:")
+        for source in enabled_sources.values():
+            print("  - %s" % (source["source"]))
+
+    # If no enabled sources were found, log it.
+    if not found:
+        logger.warning("No enabled sources.")

--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2017 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from __future__ import print_function
+
+import logging
+
+from suricata.update import sources
+
+logger = logging.getLogger()
+
+def register(parser):
+    parser.set_defaults(func=list_sources)
+
+def list_sources(config):
+    if not sources.source_index_exists(config):
+        logger.warning(
+            "Source index does not exist, please run: "
+            "suricata-update update-sources")
+        return 1
+    index = sources.load_source_index(config)
+    for name, source in index.get_sources().items():
+        print("Name: %s" % (name))
+        print("  Vendor: %s" % (source["vendor"]))
+        print("  Summary: %s" % (source["summary"]))
+        print("  License: %s" % (source["license"]))
+        if "tags" in source:
+            print("  Tags: %s" % ", ".join(source["tags"]))

--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import logging
 
 from suricata.update import sources
+from suricata.update import util
 
 logger = logging.getLogger()
 
@@ -33,9 +34,14 @@ def list_sources(config):
         return 1
     index = sources.load_source_index(config)
     for name, source in index.get_sources().items():
-        print("Name: %s" % (name))
-        print("  Vendor: %s" % (source["vendor"]))
-        print("  Summary: %s" % (source["summary"]))
-        print("  License: %s" % (source["license"]))
+        print("%s: %s" % (util.bright_cyan("Name"), util.bright_magenta(name)))
+        print("  %s: %s" % (
+            util.bright_cyan("Vendor"), util.bright_magenta(source["vendor"])))
+        print("  %s: %s" % (
+            util.bright_cyan("Summary"), util.bright_magenta(source["summary"])))
+        print("  %s: %s" % (
+            util.bright_cyan("License"), util.bright_magenta(source["license"])))
         if "tags" in source:
-            print("  Tags: %s" % ", ".join(source["tags"]))
+            print("  %s: %s" % (
+                util.bright_cyan("Tags"),
+                util.bright_magenta(", ".join(source["tags"]))))

--- a/suricata/update/configs/update.yaml
+++ b/suricata/update/configs/update.yaml
@@ -38,12 +38,12 @@ ignore:
 # Remote rule sources.
 sources:
   # Emerging Threats Open
-  - type: etopen
+  - source: etopen
   # Emerging Threats Pro
-  - type: etpro
+  - source: etpro
     code: xxxxx
   # A URL
-  - type: url
+  - source: url
     url: https://sslbl.abuse.ch/blacklist/sslblacklist.rules
 
 # A list of local rule sources. Each entry can be a rule file, a

--- a/suricata/update/configs/update.yaml
+++ b/suricata/update/configs/update.yaml
@@ -35,16 +35,12 @@ ignore:
 # May be overrided by the --reload-command command line option.
 #reload-command: sudo systemctl reload suricata
 
-# Remote rule sources.
+# Remote rule sources. Simply a list of URLs.
 sources:
-  # Emerging Threats Open
-  - source: etopen
-  # Emerging Threats Pro
-  - source: etpro
-    code: xxxxx
-  # A URL
-  - source: url
-    url: https://sslbl.abuse.ch/blacklist/sslblacklist.rules
+  # Emerging Threats Open with the Suricata version dynamically replaced.
+  - https://rules.emergingthreats.net/open/suricata-%(__version__)s/emerging.rules.tar.gz
+  # The SSL blacklist, which is just a standalone rule file.
+  - https://sslbl.abuse.ch/blacklist/sslblacklist.rules
 
 # A list of local rule sources. Each entry can be a rule file, a
 # directory or a wild card specification.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -52,6 +52,12 @@ from suricata.update import util
 from suricata.update import sources
 from suricata.update import commands
 
+from suricata.update.version import version
+try:
+    from suricata.update.revision import revision
+except:
+    revision = "unknown"
+
 # Initialize logging, use colour if on a tty.
 if len(logging.root.handlers) == 0 and os.isatty(sys.stderr.fileno()):
     logger = logging.getLogger()
@@ -1159,9 +1165,8 @@ def _main():
     if args.quiet:
         logger.setLevel(logging.WARNING)
 
-    logger.debug("This is suricata-update version %s; Python: %s" % (
-        suricata.update.version,
-        sys.version.replace("\n", "- ")))
+    logger.debug("This is suricata-update version %s (rev: %s); Python: %s" % (
+        version, revision, sys.version.replace("\n", "- ")))
 
     config = Config(args)
     try:
@@ -1189,7 +1194,7 @@ def _main():
         return dump_sample_configs()
 
     if args.version:
-        print("suricata-update version %s" % suricata.update.version)
+        print("suricata-update version %s (rev: %s)" % (version, revision))
         return 0
 
     if args.help:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -70,10 +70,10 @@ DEFAULT_SURICATA_VERSION = "4.0.0"
 # single file concatenating all input rule files together.
 DEFAULT_OUTPUT_RULE_FILENAME = "suricata.rules"
 
-class InvalidConfigurationError(Exception):
+class ApplicationError(Exception):
     pass
 
-class ApplicationError(Exception):
+class InvalidConfigurationError(ApplicationError):
     pass
 
 class AllRuleMatcher(object):
@@ -328,7 +328,8 @@ class Fetch:
     def fetch(self, url):
         tmp_filename = self.get_tmp_filename(url)
         if not self.args.force and os.path.exists(tmp_filename):
-            if time.time() - os.stat(tmp_filename).st_mtime < (60 * 15):
+            if not self.args.now and \
+               time.time() - os.stat(tmp_filename).st_mtime < (60 * 15):
                 logger.info(
                     "Last download less than 15 minutes ago. Not downloading %s.",
                     url)
@@ -1100,6 +1101,11 @@ def _main():
 
     update_parser.add_argument("-h", "--help", action="store_true")
     
+    # Hidden argument, --now to bypass the timebased bypass of
+    # updating a ruleset.
+    update_parser.add_argument(
+        "--now", default=False, action="store_true", help=argparse.SUPPRESS)
+
     # The Python 2.7 argparse module does prefix matching which can be
     # undesirable. Reserve some names here that would match existing
     # options to prevent prefix matching.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -961,31 +961,16 @@ def load_sources(config, suricata_version):
             urls.append(url)
 
     if config.get("sources"):
-        for source in config.get("sources"):
-            source_name = None
-            if "source" in source :
-                source_name = source["source"]
-            else:
-                logger.error("Source is missing the \"source\" field.")
-                continue
+        for url in config.get("sources"):
+            url = url % internal_params
+            logger.debug("Adding source %s.", url)
+            urls.append(url)
 
-            if source_name == "url":
-                urls.append(source["url"])
-            elif source_name == "etopen":
-                urls.append(resolve_etopen_url(suricata_version))
-            else:
-                logger.error(
-                    "Unknown source: %s; "
-                    "try running suricata-update update-sources",
-                    source["source"])
-
-    # If no URLs, default to ET/Open.
-    if not urls:
-        logger.info("No sources configured, will use Emerging Threats Open")
-        urls.append(resolve_etopen_url(suricata_version))
-
-    # If --etopen is on the command line, make sure its added.
-    if config.get("etopen"):
+    # If --etopen is on the command line, make sure its added. Or if
+    # there are no URLs, default to ET/Open.
+    if config.get("etopen") or not urls:
+        if not urls:
+            logger.info("No sources configured, will use Emerging Threats Open")
         urls.append(resolve_etopen_url(suricata_version))
 
     # Converting the URLs to a set removed dupes.

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -47,7 +47,7 @@ rule_pattern = re.compile(
     r"(?P<raw>"
     r"(?P<header>"
     r"(?P<action>%s)\s*"        # Action
-    r"[^\s]*\s*"                # Protocol
+    r"(?P<proto>[^\s]*)\s*"     # Protocol
     r"[^\s]*\s*"                # Source address(es)
     r"[^\s]*\s*"                # Source port
     r"(?P<direction>[-><]+)\s*"	# Direction
@@ -87,6 +87,7 @@ class Rule(dict):
       disabled (commented)
     - **action**: The action of the rule (alert, pass, etc) as a
       string
+    - **proto**: The protocol of the rule.
     - **direction**: The direction string of the rule.
     - **gid**: The gid of the rule as an integer
     - **sid**: The sid of the rule as an integer
@@ -109,6 +110,7 @@ class Rule(dict):
         dict.__init__(self)
         self["enabled"] = enabled
         self["action"] = action
+        self["proto"] = None
         self["direction"] = None
         self["group"] = group
         self["gid"] = 1
@@ -229,8 +231,9 @@ def parse(buf, group=None):
                 action=m.group("action"),
                 group=group)
 
-    rule["direction"] = m.groupdict().get("direction", None)
     rule["header"] = m.groupdict().get("header", None)
+    rule["proto"] = m.groupdict().get("proto", None)
+    rule["direction"] = m.groupdict().get("direction", None)
 
     options = m.group("options")
 

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2017 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from __future__ import print_function
+
+import os
+import logging
+import io
+import argparse
+
+import yaml
+
+from suricata.update import net
+from suricata.update import util
+
+logger = logging.getLogger()
+
+DEFAULT_SOURCE_INDEX_URL = "https://raw.githubusercontent.com/jasonish/suricata-intel-index/master/index.yaml"
+SOURCE_INDEX_FILENAME = "index.yaml"
+
+def get_source_index_url(config):
+    if os.getenv("SOURCE_INDEX_URL"):
+        return os.getenv("SOURCE_INDEX_URL")
+    return DEFAULT_SOURCE_INDEX_URL
+
+def update_sources(config):
+    source_cache_filename = os.path.join(
+        config.get_cache_dir(), SOURCE_INDEX_FILENAME)
+    source_templates = {}
+    with io.BytesIO() as fileobj:
+        try:
+            url = get_source_index_url(config)
+            logger.debug("Downloading %s", url)
+            net.get(get_source_index_url(config), fileobj)
+        except Exception as err:
+            raise Exception("Failed to download index: %s: %s" % (url, err))
+        with open(source_cache_filename, "w") as outobj:
+            outobj.write(fileobj.getvalue())
+        logger.debug("Saved %s", source_cache_filename)
+
+def load_sources(config):
+    sources_cache_filename = os.path.join(
+        config.get_cache_dir(), SOURCE_INDEX_FILENAME)
+    if os.path.exists(sources_cache_filename):
+        index = yaml.load(open(sources_cache_filename).read())
+        return index["sources"]
+    return {}
+
+def list_sources(config):
+    sources = load_sources(config)
+    if not sources:
+        logger.error("No sources exist. Try running update-sources.")
+        return
+    for name, source in sources.items():
+        print("Name: %s" % (name))
+        print("  Vendor: %s" % (source["vendor"]))
+        print("  Description: %s" % (source["description"]))
+        print("  License: %s" % (source["license"]))
+
+def enable_source(config):
+    name = config.args.name
+    sources = load_sources(config)
+    if not config.args.name in sources:
+        logger.error("Unknown source: %s", config.args.name)
+        return 1
+
+    # Parse key=val options.
+    opts = {}
+    for opt in config.args.params:
+        key, val = opt.params("=", 1)
+        opts[key] = val
+
+    source = sources[config.args.name]
+    params = {}
+    if "parameters" in source:
+        for param in source["parameters"]:
+            if param in opts:
+                params[param] = opts[param]
+            else:
+                prompt = source["parameters"][param]["prompt"]
+                r = raw_input("%s (%s): " % (prompt, param))
+                params[param] = r.strip()
+    new_source = {
+        "source": name,
+    }
+    if params:
+        new_source["params"] = params
+    new_sources = [new_source]
+    config.save_new_source(new_source)

--- a/suricata/update/util.py
+++ b/suricata/update/util.py
@@ -74,3 +74,22 @@ class ZipArchiveReader:
         zf = zipfile.ZipFile(fileobj)
         return cls(zf)
 
+GREEN = "\x1b[32m"
+BLUE = "\x1b[34m"
+REDB = "\x1b[1;31m"
+YELLOW = "\x1b[33m"
+RED = "\x1b[31m"
+YELLOWB = "\x1b[1;33m"
+ORANGE = "\x1b[38;5;208m"
+BRIGHT_MAGENTA = "\x1b[1;35m"
+BRIGHT_CYAN = "\x1b[1;36m"
+RESET = "\x1b[0m"
+
+def blue(msg):
+    return "%s%s%s" % (BLUE, msg, RESET)
+
+def bright_magenta(msg):
+    return "%s%s%s" % (BRIGHT_MAGENTA, msg, RESET)
+
+def bright_cyan(msg):
+    return "%s%s%s" % (BRIGHT_CYAN, msg, RESET)

--- a/suricata/update/version.py
+++ b/suricata/update/version.py
@@ -1,0 +1,6 @@
+# Version format:
+# Release: 1.0.0
+# Beta: 1.0.0b1
+# Alpha: 1.0.0a1
+# Development: 1.0.0.dev0
+version = "1.0.0.dev0"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,6 +95,10 @@ class TestRulecat(unittest.TestCase):
                  "--no-test",
                  "--reload-command", "true",
                 ],
+                env={
+                    "PATH": os.getenv("PATH"),
+                    "SOURCE_DIRECTORY": "/tmp",
+                },
                 stdout=open("./tmp/stdout", "wb"),
                 stderr=open("./tmp/stderr", "wb"),
             )
@@ -134,6 +138,10 @@ class TestRulecat(unittest.TestCase):
                  "--no-test",
                  "--reload-command", "true",
                 ],
+                env={
+                    "PATH": os.getenv("PATH"),
+                    "SOURCE_DIRECTORY": "/tmp",
+                },
                 stdout=open("./tmp/stdout", "wb"),
                 stderr=open("./tmp/stderr", "wb"),
             )


### PR DESCRIPTION
Adds support for a source index. The index is an online file containing known sources that can easily be enabled. To support working with sources the following commands have been added:
- update-sources - downloads the index
- enable-source - enable a source from the index
- disable-source - disable an enabled source
- remove-source - remove a source, just removes the configuration; the source stays in the index
- add-source - add a custom source with a URL

Embedded support for ET/Pro has been dropped. Its now in the index. Support for ET/Open still exists as the default ruleset if no other is specified.

The "sources" field in /etc/suricata/update.yaml is now just a list of URLs, as we'll use the index for named sources.

Quick start guide is here: https://github.com/jasonish/suricata-update/wiki/Quick-Start

This will be migrated into the doc/ directory.
