### PR TITLE
version 1.0.0a1 - v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## unreleased
-- Initial release of Suricata-Update. A Suricata rule update tool
+## 1.0.0a - 2017-12-05
+- Initial alpha release of Suricata-Update. A Suricata rule update tool
   based on idstools-rulecat, relicensed under the GPLv2 with copyright
   assigned to the OISF.
 - Features are derived from idstools-rulecat, but with more

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include suricata/update/configs/*.conf
 include suricata/update/configs/*.in
+include suricata/update/configs/*.yaml

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ The tool for updating your Suricata rules.
 Installation
 ------------
 
-    pip install https://github.com/OISF/suricata-update/archive/master.zip
+    pip install --pre --upgrade suricata-update
 
 Documentation
 -------------

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -16,11 +16,11 @@ directory for use by your user.
 
 To install ``suricata-update`` globally::
 
-    pip install --pre --upgrade https://github.com/OISF/suricata-update/archive/master.zip
+    pip install --pre --upgrade suricata-update
 
 or to install it to your own directory::
 
-    pip install --user --pre --upgrade https://github.com/OISF/suricata-update/archive/master.zip
+    pip install --user --pre --upgrade suricata-update
 
 .. note:: When installing to your home directory the
           ``suricata-update`` program will be installed to

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -29,7 +29,7 @@ from suricata.update import loghandler
 
 logger = logging.getLogger()
 
-DEFAULT_SOURCE_INDEX_URL = "https://raw.githubusercontent.com/jasonish/suricata-intel-index/master/index.yaml"
+DEFAULT_SOURCE_INDEX_URL = "https://www.openinfosecfoundation.org/rules/index.yaml"
 SOURCE_INDEX_FILENAME = "index.yaml"
 DEFAULT_SOURCE_DIRECTORY = "/var/lib/suricata/update/sources"
 

--- a/suricata/update/version.py
+++ b/suricata/update/version.py
@@ -3,4 +3,4 @@
 # Beta: 1.0.0b1
 # Alpha: 1.0.0a1
 # Development: 1.0.0.dev0
-version = "1.0.0.dev0"
+version = "1.0.0a1"


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-update/pull/15

Sets the version to 1.0.0a1. Updates doc bits since we'll push to PyPI.

Also include the sample update.yaml in the distribution package, forgot to do this earlier.

Update the index URL to one hosted by the OISF.
