### PR TITLE
Various fixes - v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ _work
 
 # The file containing the git revision.
 /suricata/update/revision.py*
+
+# Working files for the tox testing framework.
+/.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ python:
   - "3.5"
   - "3.6"
 
-script: nosetests
+script: PYTHONPATH=. pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## unreleased
+- Various fixes for Python 3.
+- Allow the default state directory of /var/lib/suricata to be changed
+  with the command line parameter -D (--data-dir). Fixes issue
+  https://redmine.openinfosecfoundation.org/issues/2334.
+- Cache directory is now /var/lib/suricata/update/cache (or
+  update/cache under configured data directory).
+- list-sources: If no index is found, automatically run
+  update-sources. Fixes issue
+  https://redmine.openinfosecfoundation.org/issues/2336.
+- New testing framework, integration tests and a docket test with the
+  focus of testing on more versions of Python.
+
 ## 1.0.0a - 2017-12-05
 - Initial alpha release of Suricata-Update. A Suricata rule update tool
   based on idstools-rulecat, relicensed under the GPLv2 with copyright

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,17 @@ build:
 install:
 	python setup.py install
 
-test:
+tox:
 	@if ! which tox 2>&1 > /dev/null; then \
 		echo "error: tox required to run tests"; \
 		exit 1; \
 	fi
+
+test: tox
 	@tox
+
+integration-test: tox
+	@tox -c tox-integration.ini
 
 clean:
 	find . -name \*.pyc -print0 | xargs -0 rm -f

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,11 @@ install:
 	python setup.py install
 
 test:
-	@if which nosetests-3 2>&1 > /dev/null; then \
-		echo "Running nosetests-3."; \
-		nosetests-3; \
+	@if ! which tox 2>&1 > /dev/null; then \
+		echo "error: tox required to run tests"; \
+		exit 1; \
 	fi
-	@if which nosetests-2 2>&1 > /dev/null; then \
-		echo "Running nosetests-2."; \
-		nosetests-2; \
-	fi
-	@echo "Running nosetests."
-	@nosetests
+	@tox
 
 clean:
 	find . -name \*.pyc -print0 | xargs -0 rm -f

--- a/doc/common-options.rst
+++ b/doc/common-options.rst
@@ -1,3 +1,19 @@
+.. option:: -h, --help
+
+   Show help.
+
+.. option:: -D <directory>, --data-dir <directory>
+
+   Set an alternate data directory.
+
+   Default: */var/lib/suricata*
+
+.. option:: -c <filename>, --config <filename>
+
+   Path to the suricata-update config file.
+
+   Default: */etc/suricata/update.yaml*
+
 .. option:: -q, --quiet
 
    Run quietly. Only warning and error messages will be displayed.

--- a/doc/disable-source.rst
+++ b/doc/disable-source.rst
@@ -15,3 +15,8 @@ Description
 The ``disable-source`` command disables a currently enabled
 source. The configuration for the source is not removed, allowing it
 to be re-enabled without having to re-enter any required parameters.
+
+Options
+=======
+
+.. include:: ./common-options.rst

--- a/doc/enable-source.rst
+++ b/doc/enable-source.rst
@@ -24,3 +24,8 @@ For example::
 
 This will prevent the prompt for the et/pro secret code using the
 value provided on the command line instead.
+
+Options
+=======
+
+.. include:: ./common-options.rst

--- a/doc/remove-source.rst
+++ b/doc/remove-source.rst
@@ -14,3 +14,8 @@ Description
 
 Remove a source configuration. This removes the source file from
 ``/var/lib/suricata/update/sources``, even if its disabled.
+
+Options
+=======
+
+.. include:: ./common-options.rst

--- a/doc/update.rst
+++ b/doc/update.rst
@@ -16,15 +16,7 @@ management tool for Suricata.
 Options
 =======
 
-.. option:: -h, --help
-
-   Show help.
-
-.. option:: -c <filename>, --config <filename>
-   
-   Path to the suricata-update config file.
-
-   Default: */etc/suricata/update.yaml*
+.. include:: ./common-options.rst
 
 .. option:: -o, --output
 
@@ -190,8 +182,6 @@ Options
 .. option:: -V, --version
 
    Display the version of **suricata-update**.
-
-.. include:: ./common-options.rst
 
 Rule Matching
 =============

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def write_revision():
         revision = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"])
         with open("./suricata/update/revision.py", "w") as fileobj:
-            fileobj.write("revision = '%s'" % (revision.strip()))
+            fileobj.write("revision = '%s'" % (revision.decode().strip()))
     except Exception as err:
         print("Failed to get current git revision: %s" % (err))
 

--- a/suricata/update/commands/addsource.py
+++ b/suricata/update/commands/addsource.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import logging
 
+from suricata.update import config
 from suricata.update import sources
 
 logger = logging.getLogger()
@@ -27,8 +28,8 @@ def register(parser):
     parser.add_argument("url", metavar="<url>", help="Source URL")
     parser.set_defaults(func=add_source)
 
-def add_source(config):
-    args = config.args
+def add_source():
+    args = config.args()
 
     if args.name:
         name = args.name

--- a/suricata/update/commands/disablesource.py
+++ b/suricata/update/commands/disablesource.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import os
 import logging
 
+from suricata.update import config
 from suricata.update import sources
 
 logger = logging.getLogger()
@@ -27,8 +28,8 @@ def register(parser):
     parser.add_argument("name")
     parser.set_defaults(func=disable_source)
 
-def disable_source(config):
-    name = config.args.name
+def disable_source():
+    name = config.args().name
     filename = sources.get_enabled_source_filename(name)
     if not os.path.exists(filename):
         logger.debug("Filename %s does not exist.", filename)

--- a/suricata/update/commands/enablesource.py
+++ b/suricata/update/commands/enablesource.py
@@ -134,6 +134,6 @@ def write_source_config(config, enabled):
         filename = sources.get_enabled_source_filename(config.name)
     else:
         filename = sources.get_disabled_source_filename(config.name)
-    with open(filename, "wb") as fileobj:
+    with open(filename, "w") as fileobj:
         logger.debug("Writing %s", filename)
         fileobj.write(yaml.safe_dump(config.dict(), default_flow_style=False))

--- a/suricata/update/commands/enablesource.py
+++ b/suricata/update/commands/enablesource.py
@@ -21,6 +21,7 @@ import logging
 
 import yaml
 
+from suricata.update import config
 from suricata.update import sources
 
 logger = logging.getLogger()
@@ -32,8 +33,8 @@ def register(parser):
     parser.add_argument("params", nargs="*", metavar="param=val")
     parser.set_defaults(func=enable_source)
 
-def enable_source(config):
-    name = config.args.name
+def enable_source():
+    name = config.args().name
 
     # Check if source is already enabled.
     enabled_source_filename = sources.get_enabled_source_filename(name)
@@ -49,7 +50,7 @@ def enable_source(config):
         os.rename(disabled_source_filename, enabled_source_filename)
         return 0
 
-    if not os.path.exists(sources.get_index_filename(config)):
+    if not os.path.exists(sources.get_index_filename()):
         logger.warning(
             "Source index does not exist, "
             "try running suricata-update update-sources.")
@@ -63,7 +64,7 @@ def enable_source(config):
 
     # Parse key=val options.
     opts = {}
-    for param in config.args.params:
+    for param in config.args().params:
         key, val = param.split("=", 1)
         opts[key] = val
 

--- a/suricata/update/commands/listenabledsources.py
+++ b/suricata/update/commands/listenabledsources.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import logging
 
+from suricata.update import config
 from suricata.update import sources
 
 logger = logging.getLogger()
@@ -25,7 +26,7 @@ logger = logging.getLogger()
 def register(parser):
     parser.set_defaults(func=list_enabled_sources)
 
-def list_enabled_sources(config):
+def list_enabled_sources():
 
     found = False
 

--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import logging
 
+from suricata.update import config
 from suricata.update import sources
 from suricata.update import util
 
@@ -26,7 +27,7 @@ logger = logging.getLogger()
 def register(parser):
     parser.set_defaults(func=list_sources)
 
-def list_sources(config):
+def list_sources():
     if not sources.source_index_exists(config):
         logger.warning(
             "Source index does not exist, please run: "

--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -21,6 +21,7 @@ import logging
 from suricata.update import config
 from suricata.update import sources
 from suricata.update import util
+from suricata.update.commands.updatesources import update_sources
 
 logger = logging.getLogger()
 
@@ -29,10 +30,8 @@ def register(parser):
 
 def list_sources():
     if not sources.source_index_exists(config):
-        logger.warning(
-            "Source index does not exist, please run: "
-            "suricata-update update-sources")
-        return 1
+        logger.info("No source index found, running update-sources")
+        update_sources()
     index = sources.load_source_index(config)
     for name, source in index.get_sources().items():
         print("%s: %s" % (util.bright_cyan("Name"), util.bright_magenta(name)))

--- a/suricata/update/commands/removesource.py
+++ b/suricata/update/commands/removesource.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import os
 import logging
 
+from suricata.update import config
 from suricata.update import sources
 
 logger = logging.getLogger()
@@ -27,8 +28,8 @@ def register(parser):
     parser.add_argument("name")
     parser.set_defaults(func=remove_source)
 
-def remove_source(config):
-    name = config.args.name
+def remove_source():
+    name = config.args().name
 
     enabled_source_filename = sources.get_enabled_source_filename(name)
     if os.path.exists(enabled_source_filename):

--- a/suricata/update/commands/updatesources.py
+++ b/suricata/update/commands/updatesources.py
@@ -20,6 +20,7 @@ import os
 import logging
 import io
 
+from suricata.update import config
 from suricata.update import sources
 from suricata.update import net
 
@@ -28,11 +29,11 @@ logger = logging.getLogger()
 def register(parser):
     parser.set_defaults(func=update_sources)
 
-def update_sources(config):
-    local_index_filename = sources.get_index_filename(config)
+def update_sources():
+    local_index_filename = sources.get_index_filename()
     with io.BytesIO() as fileobj:
         try:
-            url = sources.get_source_index_url(config)
+            url = sources.get_source_index_url()
             logger.info("Downloading %s", url)
             net.get(url, fileobj)
         except Exception as err:

--- a/suricata/update/commands/updatesources.py
+++ b/suricata/update/commands/updatesources.py
@@ -44,6 +44,6 @@ def update_sources(config):
                 logger.error("Failed to create directory %s: %s",
                              config.get_cache_dir(), err)
                 return 1
-        with open(local_index_filename, "w") as outobj:
+        with open(local_index_filename, "wb") as outobj:
             outobj.write(fileobj.getvalue())
         logger.info("Saved %s", local_index_filename)

--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2017 Open Information Security Foundation
+# Copyright (c) 2015-2017 Jason Ish
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+import os.path
+import logging
+
+import yaml
+
+logger = logging.getLogger()
+
+DEFAULT_STATE_DIRECTORY = "/var/lib/suricata"
+
+# Configuration keys.
+STATE_DIRECTORY_KEY = "state-directory"
+CACHE_DIRECTORY_KEY = "cache-directory"
+IGNORE_KEY = "ignore"
+DISABLE_CONF_KEY = "disable-conf"
+ENABLE_CONF_KEY = "enable-conf"
+MODIFY_CONF_KEY = "modify-conf"
+DROP_CONF_KEY = "drop-conf"
+LOCAL_CONF_KEY = "local"
+
+DEFAULT_UPDATE_YAML_PATH = "/etc/suricata/update.yaml"
+
+DEFAULT_CONFIG = {
+    "disable-conf": "/etc/suricata/disable.conf",
+    "enable-conf": "/etc/suricata/enable.conf",
+    "drop-conf": "/etc/suricata/drop.conf",
+    "modify-conf": "/etc/suricata/modify.conf",
+    "sources": [],
+    LOCAL_CONF_KEY: [],
+
+    # The default file patterns to ignore.
+    "ignore": [
+        "*deleted.rules",
+    ],
+}
+
+_args = None
+_config = {}
+
+def set(key, value):
+    """Set a configuration value."""
+    _config[key] = value
+
+def get(key):
+    """Get a configuration value."""
+    if key in _config:
+        return _config[key]
+    return None
+
+def set_state_dir(directory):
+    _config[STATE_DIRECTORY_KEY] = directory
+
+def get_state_dir():
+    if STATE_DIRECTORY_KEY in _config:
+        return _config[STATE_DIRECTORY_KEY]
+    return DEFAULT_STATE_DIRECTORY
+
+def set_cache_dir(directory):
+    """Set an alternate cache directory."""
+    _config[CACHE_DIRECTORY_KEY] = directory
+
+def get_cache_dir():
+    """Get the cache directory."""
+    if CACHE_DIRECTORY_KEY in _config:
+        return _config[CACHE_DIRECTORY_KEY]
+    return os.path.join(_args.output, ".cache")
+
+def args():
+    """Return sthe parsed argument object."""
+    return _args
+
+def get_arg(key):
+    key = key.replace("-", "_")
+    if hasattr(_args, key):
+        val = getattr(_args, key)
+        if val not in [[], None]:
+            return val
+    return None
+
+def init(args):
+    global _args
+
+    _args = args
+    _config.update(DEFAULT_CONFIG)
+
+    if args.config:
+        logger.info("Loading %s", args.config)
+        with open(args.config, "rb") as fileobj:
+            config = yaml.load(fileobj)
+            if config:
+                _config.update(config)
+    elif os.path.exists(DEFAULT_UPDATE_YAML_PATH):
+        logger.info("Loading %s", DEFAULT_UPDATE_YAML_PATH)
+        with open(DEFAULT_UPDATE_YAML_PATH, "rb") as fileobj:
+            config = yaml.load(fileobj)
+            if config:
+                _config.update(config)
+
+    # Apply command line arguments to the config.
+
+    for arg in vars(args):
+        if arg == "local":
+            for local in args.local:
+                logger.debug("Adding local ruleset to config: %s", local)
+                _config[LOCAL_CONF_KEY].append(local)
+        elif arg == "data_dir":
+            logger.debug("Setting data directory to %s", args.data_dir)
+            _config[DATA_DIRECTORY_KEY] = args.data_dir
+        elif getattr(args, arg):
+            _config[arg.replace("_", "-")] = getattr(args, arg)

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -33,6 +33,13 @@ import glob
 import io
 
 try:
+    # Python 3.
+    from urllib.error import HTTPError
+except ImportError:
+    # Python 2.7.
+    from urllib2 import URLError
+
+try:
     import yaml
 except:
     print("error: pyyaml is required")
@@ -374,8 +381,9 @@ class Fetch:
             files = {}
         if url:
             try:
-                files.update(self.fetch(url))
-            except Exception as err:
+                fetched = self.fetch(url)
+                files.update(fetched)
+            except URLError as err:
                 logger.error("Failed to fetch %s: %s", url, err)
         else:
             for url in self.args.url:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1037,7 +1037,8 @@ def _main():
     # Arguments that are common to all sub-commands.
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument(
-        "-c", "--config", metavar="<filename>", help="Configuration file")
+        "-c", "--config", metavar="<filename>",
+        help="Suricata-Update configuration file (default: /etc/suricata/update.yaml)")
     common_parser.add_argument(
         "-v", "--verbose", action="store_true", default=False,
         help="Be more verbose")

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -771,22 +771,6 @@ class FileTracker:
                 return True
         return False
 
-def resolve_etopen_url(suricata_version):
-    # Template URL for Emerging Threats Open rules.
-    template_url = ("https://rules.emergingthreats.net/open/"
-                    "suricata%(version)s/"
-                    "emerging.rules.tar.gz")
-
-    mappings = {
-        "version": "",
-    }
-
-    mappings["version"] = "-%d.%d.%d" % (suricata_version.major,
-                                         suricata_version.minor,
-                                         suricata_version.patch)
-
-    return template_url % mappings
-
 def ignore_file(ignore_files, filename):
     if not ignore_files:
         return False
@@ -916,7 +900,7 @@ def load_sources(suricata_version):
     if config.get("etopen") or not urls:
         if not urls:
             logger.info("No sources configured, will use Emerging Threats Open")
-        urls.append(resolve_etopen_url(suricata_version))
+        urls.append(sources.get_etopen_url(internal_params))
 
     # Converting the URLs to a set removed dupes.
     urls = set(urls)

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -18,6 +18,7 @@
 """ Module for network related operations. """
 
 import platform
+import logging
 
 try:
     # Python 3.3...
@@ -29,6 +30,8 @@ except ImportError:
     from urllib2 import HTTPError
 
 from suricata.update.version import version
+
+logger = logging.getLogger()
 
 # Number of bytes to read at a time in a GET request.
 GET_BLOCK_SIZE = 8192
@@ -45,7 +48,7 @@ def build_user_agent():
     uname_system = platform.uname()[0]
 
     params.append("OS: %s" % (uname_system))
-    params.append("CPU: %s" % (platform.processor()))
+    params.append("CPU: %s" % (platform.machine()))
     params.append("Python: %s" % (platform.python_version()))
 
     if uname_system == "Linux":
@@ -74,6 +77,7 @@ def get(url, fileobj, progress_hook=None):
     """
 
     user_agent = build_user_agent()
+    logger.debug("Setting HTTP user-agent to %s", user_agent)
 
     opener = build_opener()
     opener.addheaders = [

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -68,7 +68,7 @@ def get_source_index_url(config):
     return DEFAULT_SOURCE_INDEX_URL
 
 def save_source_config(source_config):
-    with open(get_enabled_source_filename(source_config.name), "wb") as fileobj:
+    with open(get_enabled_source_filename(source_config.name), "w") as fileobj:
         fileobj.write(yaml.safe_dump(
             source_config.dict(), default_flow_style=False))
 

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -32,14 +32,10 @@ logger = logging.getLogger()
 
 DEFAULT_SOURCE_INDEX_URL = "https://www.openinfosecfoundation.org/rules/index.yaml"
 SOURCE_INDEX_FILENAME = "index.yaml"
-DEFAULT_SOURCE_DIRECTORY = "/var/lib/suricata/update/sources"
 
 def get_source_directory():
     """Return the directory where source configuration files are kept."""
-    if os.getenv("SOURCE_DIRECTORY"):
-        return os.getenv("SOURCE_DIRECTORY")
-    else:
-        return DEFAULT_SOURCE_DIRECTORY
+    return os.path.join(config.get_state_dir(), config.SOURCE_DIRECTORY)
 
 def get_index_filename():
     return os.path.join(config.get_cache_dir(), SOURCE_INDEX_FILENAME)

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -33,6 +33,8 @@ logger = logging.getLogger()
 DEFAULT_SOURCE_INDEX_URL = "https://www.openinfosecfoundation.org/rules/index.yaml"
 SOURCE_INDEX_FILENAME = "index.yaml"
 
+DEFAULT_ETOPEN_URL = "https://rules.emergingthreats.net/open/suricata-%(__version__)s/emerging.rules.tar.gz"
+
 def get_source_directory():
     """Return the directory where source configuration files are kept."""
     return os.path.join(config.get_state_dir(), config.SOURCE_DIRECTORY)
@@ -162,3 +164,7 @@ def safe_filename(name):
     name = name.replace("/", "-")
     return name
 
+def get_etopen_url(params):
+    if os.getenv("ETOPEN_URL"):
+        return os.getenv("ETOPEN_URL") % params
+    return DEFAULT_ETOPEN_URL % params

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -23,6 +23,7 @@ import argparse
 
 import yaml
 
+from suricata.update import config
 from suricata.update import net
 from suricata.update import util
 from suricata.update import loghandler
@@ -40,7 +41,7 @@ def get_source_directory():
     else:
         return DEFAULT_SOURCE_DIRECTORY
 
-def get_index_filename(config):
+def get_index_filename():
     return os.path.join(config.get_cache_dir(), SOURCE_INDEX_FILENAME)
 
 def get_enabled_source_filename(name):
@@ -60,9 +61,9 @@ def source_name_exists(name):
 
 def source_index_exists(config):
     """Return True if the source index file exists."""
-    return os.path.exists(get_index_filename(config))
+    return os.path.exists(get_index_filename())
 
-def get_source_index_url(config):
+def get_source_index_url():
     if os.getenv("SOURCE_INDEX_URL"):
         return os.getenv("SOURCE_INDEX_URL")
     return DEFAULT_SOURCE_INDEX_URL
@@ -118,7 +119,7 @@ class Index:
         return None
 
 def load_source_index(config):
-    return Index(get_index_filename(config))
+    return Index(get_index_filename())
 
 def get_enabled_sources():
     """Return a map of enabled sources, keyed by name."""

--- a/tests/docker-centos-7/Dockerfile
+++ b/tests/docker-centos-7/Dockerfile
@@ -1,0 +1,25 @@
+FROM centos:7
+
+RUN yum -y install epel-release
+RUN yum -y install \
+    git \
+    python-yaml \
+    python-pip \
+    pytest \
+    python34-yaml \
+    python34-pytest \
+    python34-pip \
+    findutils
+
+COPY / /src
+RUN find /src -name \*.pyc -delete
+
+ENV PYTEST2 py.test
+ENV PYTEST3 py.test-3
+
+ENV PIP2 pip2
+ENV PIP3 pip3
+
+WORKDIR /src
+
+CMD ["./tests/docker-centos-7/run.sh"]

--- a/tests/docker-centos-7/Makefile
+++ b/tests/docker-centos-7/Makefile
@@ -1,0 +1,6 @@
+TAG :=	suricata-update/tests/centos-7
+
+all:
+	docker build -t $(TAG) -f Dockerfile ../..
+	docker run --rm -it $(TAG)
+

--- a/tests/docker-centos-7/README.md
+++ b/tests/docker-centos-7/README.md
@@ -1,0 +1,11 @@
+This is a live test of Suricata-Update in a CentOS 7 Docker image.
+
+The following tests are performed:
+- Unit tests with Python 2 and Python 3.
+- Installation with Python 2 pip.
+- Various commands run as a user might with Python 2 install.
+- Installation with Python 3 pip.
+- Various commands run as a user might with Python 3 install.
+
+This test is "live" as the index and rule files will be downloaded
+from the internet.

--- a/tests/docker-centos-7/run.sh
+++ b/tests/docker-centos-7/run.sh
@@ -1,0 +1,54 @@
+#! /bin/sh
+
+set -e
+set -x
+
+# Test the commands in a scenario a user might.
+test_commands() {
+    # Cleanup.
+    rm -rf /var/lib/suricata
+
+    suricata-update
+    test -e /var/lib/suricata/rules/suricata.rules
+
+    suricata-update update-sources
+    test -e /var/lib/suricata/rules/.cache/index.yaml
+
+    suricata-update enable-source oisf/trafficid
+    test -e /var/lib/suricata/update/sources/et-open.yaml
+    test -e /var/lib/suricata/update/sources/oisf-trafficid.yaml
+    suricata-update
+
+    suricata-update disable-source oisf/trafficid
+    test ! -e /var/lib/suricata/update/sources/oisf-trafficid.yaml
+    test -e /var/lib/suricata/update/sources/oisf-trafficid.yaml.disabled
+
+    suricata-update remove-source oisf/trafficid
+    test ! -e /var/lib/suricata/update/sources/oisf-trafficid.yaml.disabled
+}
+
+# Python 2 unit tests.
+PYTHONPATH=. ${PYTEST2}
+
+# Python 3 unit tests.
+PYTHONPATH=. ${PYTEST3}
+
+# Install with Python 2.
+${PIP2} install .
+test -e /usr/bin/suricata-update
+
+test_commands
+
+# Uninstall Python 2 version.
+${PIP2} uninstall --yes suricata-update
+test ! -e /usr/bin/suricata-update
+
+# Install and run with Python 3.
+${PIP3} install .
+test -e /usr/bin/suricata-update
+grep python3 -s /usr/bin/suricata-update
+
+test_commands
+
+${PIP3} uninstall --yes suricata-update
+test ! -e /usr/local/bin/suricata-update

--- a/tests/docker-centos-7/run.sh
+++ b/tests/docker-centos-7/run.sh
@@ -12,7 +12,7 @@ test_commands() {
     test -e /var/lib/suricata/rules/suricata.rules
 
     suricata-update update-sources
-    test -e /var/lib/suricata/rules/.cache/index.yaml
+    test -e /var/lib/suricata/update/cache/index.yaml
 
     suricata-update enable-source oisf/trafficid
     test -e /var/lib/suricata/update/sources/et-open.yaml

--- a/tests/empty
+++ b/tests/empty
@@ -1,0 +1,1 @@
+# An empty configuration for test purposes.

--- a/tests/index.yaml
+++ b/tests/index.yaml
@@ -1,0 +1,51 @@
+# This is a version 1 formatted index.
+version: 1
+
+sources:
+
+  # Proofpoint/Emerging Threats Open ruleset.
+  et/open:
+    vendor: Proofpoint
+    license: MIT
+    summary: Emerging Threats Open Ruleset
+    url: https://rules.emergingthreats.net/open/suricata-%(__version__)s/emerging.rules.tar.gz
+
+  # Proofpoint/Emerging Threats Pro ruleset.
+  et/pro:
+    summary: Emerging Threats Pro Ruleset
+    description: |
+      Proofpoint ET Pro is a timely and accurate rule set for detecting and blocking advanced threats
+    vendor: Proofpoint
+    license: Commercial
+    url: https://rules.emergingthreatspro.com/%(secret-code)s/suricata-%(__version__)s/etpro.rules.tar.gz
+    subscribe-url: https://www.proofpoint.com/us/threat-insight/et-pro-ruleset
+    parameters:
+      secret-code:
+        prompt: Emerging Threats Pro access code
+    replaces:
+      - et/open
+
+  # The OISF Traffic ID ruleset.
+  oisf/trafficid:
+    vendor: OISF
+    summary: Suricata Traffic ID ruleset
+    license: MIT
+    url: https://raw.githubusercontent.com/jasonish/suricata-trafficid/master/rules/traffic-id.rules
+    support-url: https://redmine.openinfosecfoundation.org/
+    min-version: 4.0.0
+
+  ptresearch/attackdetection:
+    vendor: Positive Technologies
+    summary: Positive Technologies Attack Detection Team ruleset
+    description: |
+      The Attack Detection Team searches for new vulnerabilities and 0-days, reproduces it and creates PoC exploits to understand how these security flaws work and how related attacks can be detected on the network layer. Additionally, we are interested in malware and hackers’ TTPs, so we develop Suricata rules for detecting all sorts of such activities.
+    url: https://raw.githubusercontent.com/ptresearch/AttackDetection/master/pt.rules.tar.gz
+    license: Custom
+    license-url: https://raw.githubusercontent.com/ptresearch/AttackDetection/master/LICENSE
+
+  # SSBL FP blacklist ruleset.
+  sslbl/ssl-fp-blacklist:
+    summary: Abuse.ch SSL Blacklist
+    vendor: Abuse.ch
+    license: Non-Commercial
+    url: https://sslbl.abuse.ch/blacklist/sslblacklist.rules

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,0 +1,83 @@
+import sys
+import os
+import subprocess
+import shutil
+
+DATA_DIR = "./tests/tmp"
+
+def run(args):
+    subprocess.check_call(args)
+
+def delete(path):
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+    else:
+        os.unlink(path)
+
+print("Python executable: %s" % sys.executable)
+print("Current directory: %s" % os.getcwd())
+
+# Override the default source index URL to avoid hitting the network.
+os.environ["SOURCE_INDEX_URL"] = "file://%s/tests/index.yaml" % (
+    os.getcwd())
+
+os.environ["ETOPEN_URL"] = "file://%s/tests/emerging.rules.tar.gz" % (
+    os.getcwd())
+
+if os.path.exists(DATA_DIR):
+    delete(DATA_DIR)
+
+common_args = [
+    "./bin/suricata-update",
+    "-D", DATA_DIR,
+    "-c" "./tests/empty",
+]
+
+common_update_args = [
+    "--no-test",
+    "--no-reload",
+    "--disable-conf", "./tests/empty",
+    "--enable-conf", "./tests/empty",
+    "--drop-conf", "./tests/empty",
+    "--modify-conf", "./tests/empty",
+]
+
+# Default run with data directory.
+run(common_args + common_update_args)
+assert(os.path.exists(DATA_DIR))
+assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache")))
+assert(os.path.exists(os.path.join(DATA_DIR, "rules", "suricata.rules")))
+
+# Still a default run, but set --output to an alternate location."
+run(common_args + common_update_args + ["--output", "./tests/tmp/_rules"])
+assert(os.path.exists(os.path.join(DATA_DIR, "_rules")))
+
+# Update sources.
+run(common_args + ["update-sources"])
+assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache", "index.yaml")))
+
+# Now delete the index and run lists-sources to see if it downloads
+# the index.
+delete(os.path.join(DATA_DIR, "update", "cache", "index.yaml"))
+run(common_args + ["list-sources"])
+assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache", "index.yaml")))
+
+# Enable a source.
+run(common_args + ["enable-source", "oisf/trafficid"])
+assert(os.path.exists(
+    os.path.join(DATA_DIR, "update", "sources", "oisf-trafficid.yaml")))
+
+# Disable the source.
+run(common_args + ["disable-source", "oisf/trafficid"])
+assert(not os.path.exists(
+    os.path.join(
+        DATA_DIR, "update", "sources", "oisf-trafficid.yaml")))
+assert(os.path.exists(
+    os.path.join(
+        DATA_DIR, "update", "sources", "oisf-trafficid.yaml.disabled")))
+
+# Remove the source.
+run(common_args + ["remove-source", "oisf/trafficid"])
+assert(not os.path.exists(
+    os.path.join(
+        DATA_DIR, "update", "sources", "oisf-trafficid.yaml.disabled")))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -163,7 +163,7 @@ class TestFetch(unittest.TestCase):
         """Test that we detect when the checksum are the same. This is mainly
         to catch issues between Python 2 and 3.
         """
-        fetch = main.Fetch(None)
+        fetch = main.Fetch()
         url = "file://%s/emerging.rules.tar.gz" % (
             os.path.dirname(os.path.realpath(__file__)))
         local_file = "%s/emerging.rules.tar.gz" % (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,35 +17,12 @@
 
 from __future__ import print_function
 
-import sys
 import os
 import unittest
-import shlex
-import re
-import subprocess
-import shutil
 
 import suricata.update.rule
 from suricata.update import main
 import suricata.update.extract
-
-def has_python2():
-    r = subprocess.call(
-        ["python2", "--version"],
-        stderr=open("/dev/null", "wb"),
-        stdout=open("/dev/null", "wb"))
-    if r == 0:
-        return True
-    return False
-
-def has_python3():
-    r = subprocess.call(
-        ["python3", "--version"],
-        stderr=open("/dev/null", "wb"),
-        stdout=open("/dev/null", "wb"))
-    if r == 0:
-        return True
-    return False
 
 class TestRulecat(unittest.TestCase):
 
@@ -71,49 +48,6 @@ class TestRulecat(unittest.TestCase):
         files = suricata.update.extract.try_extract(
             "tests/emerging-current_events.rules")
         self.assertIsNone(files)
-
-    def test_run(self):
-        old_path = os.getcwd()
-        try:
-            os.chdir(os.path.dirname(os.path.realpath(__file__)))
-            if os.path.exists("./tmp"):
-                shutil.rmtree("tmp")
-            os.makedirs("./tmp/rules")
-            subprocess.check_call(
-                ["/usr/bin/env", sys.executable,
-                 "../bin/suricata-update",
-                 "-D", "./tmp",
-                 "-v",
-                 "-c", "./update.yaml",
-                 "--url",
-                 "file://%s/emerging.rules.tar.gz" % (
-                     os.getcwd()),
-                 "--local", "./rule-with-unicode.rules",
-                 "--force",
-                 "--output", "./tmp/rules/",
-                 "--yaml-fragment", "./tmp/suricata-rules.yaml",
-                 "--sid-msg-map", "./tmp/sid-msg.map",
-                 "--sid-msg-map-2", "./tmp/sid-msg-v2.map",
-                 "--no-test",
-                 "--reload-command", "true",
-                ],
-                env={
-                    "PATH": os.getenv("PATH"),
-                },
-                stdout=open("./tmp/stdout", "wb"),
-                stderr=open("./tmp/stderr", "wb"),
-            )
-            shutil.rmtree("tmp")
-        except:
-            if os.path.exists("./tmp/stdout"):
-                print("STDOUT")
-                print(open("./tmp/stdout").read())
-            if os.path.exists("./tmp/stderr"):
-                print("STDERR")
-                print(open("./tmp/stderr").read())
-            raise
-        finally:
-            os.chdir(old_path)
 
 class TestFetch(unittest.TestCase):
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@
 
 from __future__ import print_function
 
+import sys
 import os
 import unittest
 import shlex
@@ -71,8 +72,7 @@ class TestRulecat(unittest.TestCase):
             "tests/emerging-current_events.rules")
         self.assertIsNone(files)
 
-    @unittest.skipIf(not has_python2(), "python2 not available")
-    def test_run_python2(self):
+    def test_run(self):
         old_path = os.getcwd()
         try:
             os.chdir(os.path.dirname(os.path.realpath(__file__)))
@@ -80,8 +80,10 @@ class TestRulecat(unittest.TestCase):
                 shutil.rmtree("tmp")
             os.makedirs("./tmp/rules")
             subprocess.check_call(
-                ["/usr/bin/env", "python2",
+                ["/usr/bin/env", sys.executable,
                  "../bin/suricata-update",
+                 "-D", "./tmp",
+                 "-v",
                  "-c", "./update.yaml",
                  "--url",
                  "file://%s/emerging.rules.tar.gz" % (
@@ -97,50 +99,6 @@ class TestRulecat(unittest.TestCase):
                 ],
                 env={
                     "PATH": os.getenv("PATH"),
-                    "SOURCE_DIRECTORY": "/tmp",
-                },
-                stdout=open("./tmp/stdout", "wb"),
-                stderr=open("./tmp/stderr", "wb"),
-            )
-            shutil.rmtree("tmp")
-        except:
-            if os.path.exists("./tmp/stdout"):
-                print("STDOUT")
-                print(open("./tmp/stdout").read())
-            if os.path.exists("./tmp/stderr"):
-                print("STDERR")
-                print(open("./tmp/stderr").read())
-            raise
-        finally:
-            os.chdir(old_path)
-
-    @unittest.skipIf(not has_python3(), "python3 not available")
-    def test_run_python3(self):
-        old_path = os.getcwd()
-        try:
-            os.chdir(os.path.dirname(os.path.realpath(__file__)))
-            if os.path.exists("./tmp"):
-                shutil.rmtree("tmp")
-            os.makedirs("./tmp/rules")
-            subprocess.check_call(
-                ["/usr/bin/env", "python2",
-                 "../bin/suricata-update",
-                 "-c", "./update.yaml",
-                 "--url",
-                 "file://%s/emerging.rules.tar.gz" % (
-                     os.getcwd()),
-                 "--local", "./rule-with-unicode.rules",
-                 "--force",
-                 "--output", "./tmp/rules/",
-                 "--yaml-fragment", "./tmp/suricata-rules.yaml",
-                 "--sid-msg-map", "./tmp/sid-msg.map",
-                 "--sid-msg-map-2", "./tmp/sid-msg-v2.map",
-                 "--no-test",
-                 "--reload-command", "true",
-                ],
-                env={
-                    "PATH": os.getenv("PATH"),
-                    "SOURCE_DIRECTORY": "/tmp",
                 },
                 stdout=open("./tmp/stdout", "wb"),
                 stderr=open("./tmp/stderr", "wb"),

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -1,0 +1,13 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34, py35, py36
+
+[testenv]
+commands = python ./tests/integration_tests.py
+deps =
+    pytest
+    pyyaml

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34, py35, py36
+
+[testenv]
+commands = pytest
+deps =
+    pytest
+    pyyaml


### PR DESCRIPTION
Issue https://redmine.openinfosecfoundation.org/issues/2334.
- Based on user feedback. --output would change the cache location, not just the rule output location. To fix this introduce -D (--data-dir) to change the /var/lib/suricata location and make the cache default to /var/lib/suricata/update/cache. This way the rule output can be redirected independent of the suricata-update working directory.
- Switching the config to a module as a singleton Python idiom helped make this easier to avoid passing a config object around everywhere. This is a Pythonic thing to do.

Issue https://redmine.openinfosecfoundation.org/issues/2336.
- Automatically run update-sources when list-sources is run and no index exists.

Also add more integration type tests with the main focus of testing user scenarios with more versions of Python.
