### PR TITLE
config: configure a custom user-agent-string

### DIFF
--- a/suricata/update/configs/update.yaml
+++ b/suricata/update/configs/update.yaml
@@ -22,6 +22,9 @@ modify-conf: /etc/suricata/modify.conf
 ignore:
   - "*deleted.rules"
 
+# Override the user-agent string 
+#user-agent: "Suricata-Update"
+
 # Provide an alternate command to the default test command.
 #
 # The following environment variables can be used.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1011,6 +1011,8 @@ def _main():
     
     update_parser.add_argument("--no-merge", action="store_true", default=False,
                                help="Do not merge the rules into a single file")
+    update_parser.add_argument("--user-agent", metavar="<user-agent>",
+                               help="Set custom user-agent string")
 
     update_parser.add_argument("-h", "--help", action="store_true")
     
@@ -1180,6 +1182,12 @@ def _main():
     if drop_conf_filename and os.path.exists(drop_conf_filename):
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
+
+    # Load custom user-agent-string
+    user_agent = config.get("user-agent")
+    if user_agent:
+        logger.info("Using user-agent: %s.",user_agent)
+        suricata.update.net.set_custom_user_agent(user_agent)
 
     if os.path.exists("/etc/suricata/suricata.yaml") and \
        suricata_path and os.path.exists(suricata_path):

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -37,6 +37,11 @@ logger = logging.getLogger()
 GET_BLOCK_SIZE = 8192
 
 user_agent_suricata_verison = "Unknown"
+custom_user_agent = None
+
+def set_custom_user_agent(ua):
+    global custom_user_agent
+    custom_user_agent = ua
 
 def set_user_agent_suricata_version(version):
     global user_agent_suricata_verison
@@ -44,6 +49,9 @@ def set_user_agent_suricata_version(version):
 
 def build_user_agent():
     params = []
+
+    if custom_user_agent is not None:
+        return custom_user_agent
 
     uname_system = platform.uname()[0]
 


### PR DESCRIPTION
Includes an command-line/config-file-option for a custom user-agent string.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2344

Describe changes:
- added command-line and config-file option for "user-agent"
- wrote example-config in update.yaml
