### PR TITLE
custom user agent; test fixups - v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,15 @@ test: tox
 integration-test: tox
 	@tox -c tox-integration.ini
 
+docker-test:
+	@if ! which docker 2>&1 > /dev/null; then \
+		echo "error: docker is required to run docker tests"; \
+		exit 1; \
+	fi
+	@for test in $(wildcard tests/docker*); do \
+		(cd $$test && $(MAKE)); \
+	done
+
 clean:
 	find . -name \*.pyc -print0 | xargs -0 rm -f
 	find . -name \*~ -print0 | xargs -0 rm -f

--- a/doc/common-options.rst
+++ b/doc/common-options.rst
@@ -22,6 +22,19 @@
 
    Provide more verbose output.
 
+.. option:: --suricata <path>
+
+   The path to the Suricata program. If not provided
+   ``suricata-update`` will attempt to find Suricata on your path.
+
+   The Suricata program is used to determine the version of Suricata
+   as well as providing information about the Suricata configuration.
+
+.. option:: --suricata-version <version>
+
+   Set the Suricata version to a specific version instead of checking
+   the version of Suricata on the path.
+
 .. option:: --user-agent <string>
 
    Set a custom user agent string for HTTP requests.

--- a/doc/common-options.rst
+++ b/doc/common-options.rst
@@ -21,3 +21,7 @@
 .. option:: -v, --verbose
 
    Provide more verbose output.
+
+.. option:: --user-agent <string>
+
+   Set a custom user agent string for HTTP requests.

--- a/doc/update.rst
+++ b/doc/update.rst
@@ -24,17 +24,6 @@ Options
 
    Default: */var/lib/suricata/rules*
 
-.. option:: --suricata=<path>
-
-   The path to the Suricata program used to determine which version of
-   the ET pro rules to download if not explicitly set in a ``--url``
-   argument.
-
-.. option:: --suricata-version <version>
-
-   Set the Suricata version to a specific version instead of checking
-   the version of Suricata on the path.
-
 .. option:: --force
 
    Force remote rule files to be downloaded if they otherwise wouldn't

--- a/suricata/update/configs/update.yaml
+++ b/suricata/update/configs/update.yaml
@@ -22,6 +22,9 @@ modify-conf: /etc/suricata/modify.conf
 ignore:
   - "*deleted.rules"
 
+# Override the user-agent string.
+#user-agent: "Suricata-Update"
+
 # Provide an alternate command to the default test command.
 #
 # The following environment variables can be used.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1011,6 +1011,8 @@ def _main():
     
     update_parser.add_argument("--no-merge", action="store_true", default=False,
                                help="Do not merge the rules into a single file")
+    update_parser.add_argument("--user-agent", metavar="<user-agent>",
+                               help="Set custom user-agent string")
 
     update_parser.add_argument("-h", "--help", action="store_true")
     
@@ -1180,6 +1182,12 @@ def _main():
     if drop_conf_filename and os.path.exists(drop_conf_filename):
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
+
+    # Load custom user-agent-string
+    user_agent = config.get("user-agent")
+    if user_agent:
+        logger.info("Using user-agent: %s.",user_agent)
+        suricata.update.net.set_custom_user_agent(user_agent)
 
     if os.path.exists("/etc/suricata/suricata.yaml") and \
        suricata_path and os.path.exists(suricata_path):

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -937,6 +937,10 @@ def _main():
     global_parser.add_argument(
         "-c", "--config", metavar="<filename>",
         help="configuration file (default: /etc/suricata/update.yaml)")
+    global_parser.add_argument(
+        "--user-agent", metavar="<user-agent>",
+        help="Set custom user-agent string")
+
     global_args, rem = global_parser.parse_known_args()
 
     if not rem or rem[0].startswith("-"):
@@ -1011,8 +1015,6 @@ def _main():
     
     update_parser.add_argument("--no-merge", action="store_true", default=False,
                                help="Do not merge the rules into a single file")
-    update_parser.add_argument("--user-agent", metavar="<user-agent>",
-                               help="Set custom user-agent string")
 
     update_parser.add_argument("-h", "--help", action="store_true")
     
@@ -1082,6 +1084,12 @@ def _main():
 
     logger.debug("This is suricata-update version %s (rev: %s); Python: %s" % (
         version, revision, sys.version.replace("\n", "- ")))
+
+    # Load custom user-agent-string.
+    user_agent = config.get("user-agent")
+    if user_agent:
+        logger.info("Using user-agent: %s.", user_agent)
+        suricata.update.net.set_custom_user_agent(user_agent)
 
     if args.subcommand:
         if hasattr(args, "func"):
@@ -1182,12 +1190,6 @@ def _main():
     if drop_conf_filename and os.path.exists(drop_conf_filename):
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
-
-    # Load custom user-agent-string
-    user_agent = config.get("user-agent")
-    if user_agent:
-        logger.info("Using user-agent: %s.",user_agent)
-        suricata.update.net.set_custom_user_agent(user_agent)
 
     if os.path.exists("/etc/suricata/suricata.yaml") and \
        suricata_path and os.path.exists(suricata_path):

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -926,7 +926,7 @@ def _main():
 
     global_parser = argparse.ArgumentParser(add_help=False)
     global_parser.add_argument(
-        "-v", "--verbose", action="store_true", default=False,
+        "-v", "--verbose", action="store_true", default=None,
         help="Be more verbose")
     global_parser.add_argument(
         "-q", "--quiet", action="store_true", default=False,

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -37,6 +37,11 @@ logger = logging.getLogger()
 GET_BLOCK_SIZE = 8192
 
 user_agent_suricata_verison = "Unknown"
+custom_user_agent = None
+
+def set_custom_user_agent(ua):
+    global custom_user_agent
+    custom_user_agent = ua
 
 def set_user_agent_suricata_version(version):
     global user_agent_suricata_verison
@@ -44,6 +49,9 @@ def set_user_agent_suricata_version(version):
 
 def build_user_agent():
     params = []
+
+    if custom_user_agent is not None:
+        return custom_user_agent
 
     uname_system = platform.uname()[0]
 

--- a/tests/docker-ubuntu-1604/Dockerfile
+++ b/tests/docker-ubuntu-1604/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+RUN apt-get install -y \
+    	    python-yaml \
+    	    python3-yaml \
+	    python-pytest \
+	    python3-pytest \
+	    python-pip \
+	    python3-pip
+
+# RUN yum -y install epel-release
+# RUN yum -y install \
+#     git \
+#     python-yaml \
+#     python-pip \
+#     pytest \
+#     python34-yaml \
+#     python34-pytest \
+#     python34-pip \
+#     findutils
+
+COPY / /src
+RUN find /src -name \*.pyc -delete
+
+ENV PYTEST2 py.test
+ENV PYTEST3 py.test-3
+
+ENV PIP2 pip2
+ENV PIP3 pip3
+
+WORKDIR /src
+
+CMD ["./tests/docker-ubuntu-1604/run.sh"]

--- a/tests/docker-ubuntu-1604/Makefile
+++ b/tests/docker-ubuntu-1604/Makefile
@@ -1,0 +1,5 @@
+TAG :=	suricata-update/tests/ubuntu-1604
+
+all:
+	docker build -t $(TAG) -f Dockerfile ../..
+	docker run --rm -it $(TAG)

--- a/tests/docker-ubuntu-1604/README.md
+++ b/tests/docker-ubuntu-1604/README.md
@@ -1,0 +1,12 @@
+This is a live test of Suricata-Update in an Ubuntu 16.04 LTS Docker
+image.
+
+The following tests are performed:
+- Unit tests with Python 2 and Python 3.
+- Installation with Python 2 pip.
+- Various commands run as a user might with Python 2 install.
+- Installation with Python 3 pip.
+- Various commands run as a user might with Python 3 install.
+
+This test is "live" as the index and rule files will be downloaded
+from the internet.

--- a/tests/docker-ubuntu-1604/run.sh
+++ b/tests/docker-ubuntu-1604/run.sh
@@ -1,0 +1,54 @@
+#! /bin/sh
+
+set -e
+set -x
+
+# Test the commands in a scenario a user might.
+test_commands() {
+    # Cleanup.
+    rm -rf /var/lib/suricata
+
+    suricata-update
+    test -e /var/lib/suricata/rules/suricata.rules
+
+    suricata-update update-sources
+    test -e /var/lib/suricata/update/cache/index.yaml
+
+    suricata-update enable-source oisf/trafficid
+    test -e /var/lib/suricata/update/sources/et-open.yaml
+    test -e /var/lib/suricata/update/sources/oisf-trafficid.yaml
+    suricata-update
+
+    suricata-update disable-source oisf/trafficid
+    test ! -e /var/lib/suricata/update/sources/oisf-trafficid.yaml
+    test -e /var/lib/suricata/update/sources/oisf-trafficid.yaml.disabled
+
+    suricata-update remove-source oisf/trafficid
+    test ! -e /var/lib/suricata/update/sources/oisf-trafficid.yaml.disabled
+}
+
+# Python 2 unit tests.
+PYTHONPATH=. ${PYTEST2}
+
+# Python 3 unit tests.
+PYTHONPATH=. ${PYTEST3}
+
+# Install with Python 2.
+${PIP2} install .
+test -e /usr/local/bin/suricata-update
+
+test_commands
+
+# Uninstall Python 2 version.
+${PIP2} uninstall --yes suricata-update
+test ! -e /usr/local/bin/suricata-update
+
+# Install and run with Python 3.
+${PIP3} install .
+test -e /usr/local/bin/suricata-update
+grep python3 -s /usr/local/bin/suricata-update
+
+test_commands
+
+${PIP3} uninstall --yes suricata-update
+test ! -e /usr/local/bin/suricata-update

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -30,7 +30,7 @@ if os.path.exists(DATA_DIR):
 common_args = [
     "./bin/suricata-update",
     "-D", DATA_DIR,
-    "-c" "./tests/empty",
+    "-c", "./tests/empty",
 ]
 
 common_update_args = [


### PR DESCRIPTION
This PR includes @whotwagner PR for custom user agent: https://github.com/OISF/suricata-update/pull/19

I added some more to make it global so it would also apply to update-sources.

The check for the Suricata version was also moved up before sub-command execution so the version could be extracted for update-sources. This also moves --suricata --suricata-version to global options so they can be used for more than just the default command (mainly update-sources for now).

Also throwing in my Ubuntu 16.04 docker test.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2344
