### PR TITLE
config: configurable suricata-conf-parameter

### DIFF
--- a/doc/common-options.rst
+++ b/doc/common-options.rst
@@ -22,6 +22,12 @@
 
    Provide more verbose output.
 
+.. option:: --suricata-conf <path>
+
+   Path to the suricata config file.
+
+   Default: */etc/suricata/suricata.yaml*
+
 .. option:: --suricata <path>
 
    The path to the Suricata program. If not provided

--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -43,11 +43,18 @@ OUTPUT_KEY = "output"
 
 DEFAULT_UPDATE_YAML_PATH = "/etc/suricata/update.yaml"
 
+DEFAULT_SURICATA_YAML_PATH = [ 
+    "/etc/suricata/suricata.yaml",
+    "/usr/local/etc/suricata/suricata.yaml",
+    "/etc/suricata/suricata-debian.yaml"
+]
+
 DEFAULT_CONFIG = {
     "disable-conf": "/etc/suricata/disable.conf",
     "enable-conf": "/etc/suricata/enable.conf",
     "drop-conf": "/etc/suricata/drop.conf",
     "modify-conf": "/etc/suricata/modify.conf",
+    "suricata-conf": "/etc/suricata/suricata.conf",
     "sources": [],
     LOCAL_CONF_KEY: [],
 
@@ -117,6 +124,11 @@ def init(args):
 
     _args = args
     _config.update(DEFAULT_CONFIG)
+
+    for suriyaml in DEFAULT_SURICATA_YAML_PATH:
+        if os.path.exists(suriyaml):
+            _config["suricata-conf"] = suriyaml
+            break
 
     if args.config:
         logger.info("Loading %s", args.config)

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -938,6 +938,9 @@ def _main():
         "-c", "--config", metavar="<filename>",
         help="configuration file (default: /etc/suricata/update.yaml)")
     global_parser.add_argument(
+        "--suricata-conf", metavar="<filename>",
+        help="configuration file (default: /etc/suricata/suricata.yaml)")
+    global_parser.add_argument(
         "--suricata", metavar="<path>",
         help="Path to Suricata program")
     global_parser.add_argument(
@@ -1197,11 +1200,11 @@ def _main():
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
 
-    if os.path.exists("/etc/suricata/suricata.yaml") and \
+    if os.path.exists(config.get("suricata-conf")) and \
        suricata_path and os.path.exists(suricata_path):
-        logger.info("Loading /etc/suricata/suricata.yaml")
+        logger.info("Loading %s",config.get("suricata-conf"))
         suriconf = suricata.update.engine.Configuration.load(
-            "/etc/suricata/suricata.yaml", suricata_path=suricata_path)
+            config.get("suricata-conf"), suricata_path=suricata_path)
         for key in suriconf.keys():
             if key.startswith("app-layer.protocols") and \
                key.endswith(".enabled"):


### PR DESCRIPTION
This commit adds the command-line-parameter "suricata-conf" and replaces the hard-coded "/etc/suricata/suricata.yaml".

Ticket: Feature #2350

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2350

Describe changes:
- added "suricata-conf" parameter
- set "/etc/suricata/suricata.yaml" as default
- replaced the hardcoded /etc/suricata/suricata.yaml
