### PR TITLE
suricata path and suricata conf improvements - v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   https://redmine.openinfosecfoundation.org/issues/2336.
 - New testing framework, integration tests and a docket test with the
   focus of testing on more versions of Python.
+- Allow a custom HTTP User-Agent to be set
+  (https://redmine.openinfosecfoundation.org/issues/2344).
+- Command line option and configuration parameter to set the
+  suricata.yaml configuration file used
+  (https://redmine.openinfosecfoundation.org/issues/2350).
+- Allow the Suricata application to be set in the configuration file.
 
 ## 1.0.0a - 2017-12-05
 - Initial alpha release of Suricata-Update. A Suricata rule update tool

--- a/doc/common-options.rst
+++ b/doc/common-options.rst
@@ -22,6 +22,12 @@
 
    Provide more verbose output.
 
+.. option:: --suricata-conf <path>
+
+   Path to the suricata config file.
+
+   Default: */etc/suricata/suricata.yaml*
+
 .. option:: --suricata <path>
 
    The path to the Suricata program. If not provided

--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -43,11 +43,18 @@ OUTPUT_KEY = "output"
 
 DEFAULT_UPDATE_YAML_PATH = "/etc/suricata/update.yaml"
 
+DEFAULT_SURICATA_YAML_PATH = [
+    "/etc/suricata/suricata.yaml",
+    "/usr/local/etc/suricata/suricata.yaml",
+    "/etc/suricata/suricata-debian.yaml"
+]
+
 DEFAULT_CONFIG = {
     "disable-conf": "/etc/suricata/disable.conf",
     "enable-conf": "/etc/suricata/enable.conf",
     "drop-conf": "/etc/suricata/drop.conf",
     "modify-conf": "/etc/suricata/modify.conf",
+    "suricata-conf": "/etc/suricata/suricata.conf",
     "sources": [],
     LOCAL_CONF_KEY: [],
 
@@ -117,6 +124,11 @@ def init(args):
 
     _args = args
     _config.update(DEFAULT_CONFIG)
+
+    for suriyaml in DEFAULT_SURICATA_YAML_PATH:
+        if os.path.exists(suriyaml):
+            _config["suricata-conf"] = suriyaml
+            break
 
     if args.config:
         logger.info("Loading %s", args.config)

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -84,9 +84,9 @@ def get_path(program="suricata"):
         if not path:
             continue
         suricata_path = os.path.join(path, program)
-        logger.debug("Testing path: %s" % (path))
+        logger.debug("Looking for %s in %s" % (program, path))
         if os.path.exists(suricata_path):
-            logger.debug("Found %s." % (path))
+            logger.debug("Found %s." % (suricata_path))
             return suricata_path
     return None
 
@@ -106,14 +106,12 @@ def parse_version(buf):
             raw=buf)
     return None
 
-def get_version(path=None):
+def get_version(path):
     """Get a SuricataVersion named tuple describing the version.
 
     If no path argument is found, the envionment PATH will be
     searched.
     """
-    if not path:
-        path = get_path("suricata")
     if not path:
         return None
     output = subprocess.check_output([path, "-V"])

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -121,13 +121,15 @@ def get_version(path=None):
         return parse_version(output)
     return None
 
-def test_configuration(path, rule_filename=None):
+def test_configuration(suricata_path, suricata_conf=None, rule_filename=None):
     """Test the Suricata configuration with -T."""
     test_command = [
-        path,
+        suricata_path,
         "-T",
         "-l", "/tmp",
     ]
+    if suricata_conf:
+        test_command += ["-c", suricata_conf]
     if rule_filename:
         test_command += ["-S", rule_filename]
 
@@ -139,6 +141,7 @@ def test_configuration(path, rule_filename=None):
         "ASAN_OPTIONS": "detect_leaks=0",
     }
 
+    logger.debug("Running %s; env=%s", " ".join(test_command), str(env))
     rc = subprocess.Popen(test_command, env=env).wait()
     if rc == 0:
         return True

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -938,6 +938,9 @@ def _main():
         "-c", "--config", metavar="<filename>",
         help="configuration file (default: /etc/suricata/update.yaml)")
     global_parser.add_argument(
+        "--suricata-conf", metavar="<filename>",
+        help="configuration file (default: /etc/suricata/suricata.yaml)")
+    global_parser.add_argument(
         "--suricata", metavar="<path>",
         help="Path to Suricata program")
     global_parser.add_argument(
@@ -1197,11 +1200,11 @@ def _main():
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
 
-    if os.path.exists("/etc/suricata/suricata.yaml") and \
+    if os.path.exists(config.get("suricata-conf")) and \
        suricata_path and os.path.exists(suricata_path):
-        logger.info("Loading /etc/suricata/suricata.yaml")
+        logger.info("Loading %s",config.get("suricata-conf"))
         suriconf = suricata.update.engine.Configuration.load(
-            "/etc/suricata/suricata.yaml", suricata_path=suricata_path)
+            config.get("suricata-conf"), suricata_path=suricata_path)
         for key in suriconf.keys():
             if key.startswith("app-layer.protocols") and \
                key.endswith(".enabled"):

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -924,8 +924,6 @@ def copytree_ignore_backup(src, names):
 def _main():
     global args
 
-    suricata_path = suricata.update.engine.get_path()
-
     global_parser = argparse.ArgumentParser(add_help=False)
     global_parser.add_argument(
         "-v", "--verbose", action="store_true", default=None,
@@ -1093,12 +1091,12 @@ def _main():
         version, revision, sys.version.replace("\n", "- ")))
 
     # Check for Suricata binary...
-    if args.suricata:
-        if not os.path.exists(args.suricata):
+    if config.get("suricata"):
+        if not os.path.exists(config.get("suricata")):
             logger.error("Specified path to suricata does not exist: %s",
-                     args.suricata)
+                         config.get("suricata"))
             return 1
-        suricata_path = args.suricata
+        suricata_path = config.get("suricata")
     else:
         suricata_path = suricata.update.engine.get_path()
         if not suricata_path:
@@ -1116,7 +1114,7 @@ def _main():
             return 1
         logger.info("Forcing Suricata version to %s." % (suricata_version.full))
     elif suricata_path:
-        suricata_version = suricata.update.engine.get_version(args.suricata)
+        suricata_version = suricata.update.engine.get_version(suricata_path)
         if suricata_version:
             logger.info("Found Suricata version %s at %s." % (
                 str(suricata_version.full), suricata_path))

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -804,14 +804,16 @@ def test_suricata(suricata_path):
             return False
     else:
         logger.info("Testing with suricata -T.")
+        suricata_conf = config.get("suricata-conf")
         if not config.get("no-merge"):
             if not suricata.update.engine.test_configuration(
-                    suricata_path, os.path.join(
+                    suricata_path, suricata_conf,
+                    os.path.join(
                         config.get_output_dir(), DEFAULT_OUTPUT_RULE_FILENAME)):
                 return False
         else:
             if not suricata.update.engine.test_configuration(
-                    suricata_path):
+                    suricata_path, suricata_conf):
                 return False
 
     return True


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [X] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- https://redmine.openinfosecfoundation.org/issues/2350

Describe changes:
- Allows the suricata configuration file to be specified on the command line or configuration file.
- Allow suricata program to be specified in the configuration file.
