### PR TITLE
(Remote)Code-Execution while loading yaml-file

### DIFF
--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -133,13 +133,13 @@ def init(args):
     if args.config:
         logger.info("Loading %s", args.config)
         with open(args.config, "rb") as fileobj:
-            config = yaml.load(fileobj)
+            config = yaml.safe_load(fileobj)
             if config:
                 _config.update(config)
     elif os.path.exists(DEFAULT_UPDATE_YAML_PATH):
         logger.info("Loading %s", DEFAULT_UPDATE_YAML_PATH)
         with open(DEFAULT_UPDATE_YAML_PATH, "rb") as fileobj:
-            config = yaml.load(fileobj)
+            config = yaml.safe_load(fileobj)
             if config:
                 _config.update(config)
 

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -96,7 +96,7 @@ class Index:
         self.reload()
 
     def reload(self):
-        index = yaml.load(open(self.filename, "rb"))
+        index = yaml.safe_load(open(self.filename, "rb"))
         self.index = index
 
     def resolve_url(self, name, params={}):
@@ -128,7 +128,7 @@ def get_enabled_sources():
         for filename in filenames:
             if filename.endswith(".yaml"):
                 path = os.path.join(dirpath, filename)
-                source = yaml.load(open(path, "rb"))
+                source = yaml.safe_load(open(path, "rb"))
                 sources[source["source"]] = source
 
                 if "params" in source:


### PR DESCRIPTION
The list of possible sources for suricata-update is downloaded from "https://www.openinfosecfoundation.org/rules/index.yaml" per default. Suricata-Update uses the insecure yaml.load()-function. Code will be executed if the yaml-file contains lines like:

hello: !!python/object/apply:os.system ['ls -l > /tmp/output']

The vulnerable function can be triggered by "suricata-update list-sources". The locally stored index.yaml will be loaded in this function and the malicious code gets executed.

This commit fixes Bug #2359

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2359

Describe changes:
- replaced yaml.load by yaml.safe_load
