### PR TITLE
list-sources: print subscribe URL

### DIFF
--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -53,3 +53,7 @@ def list_sources():
             print("  %s: %s" % (
                 util.bright_cyan("Parameters"),
                 util.bright_magenta(", ".join(source["parameters"]))))
+        if "subscribe-url" in source:
+            print("  %s: %s" % (
+                util.bright_cyan("Subscription"),
+                util.bright_magenta(source["subscribe-url"])))


### PR DESCRIPTION
The subscribe URL may be a sentence with a URL in it which may
contain useful information.

To support the extra information required in the Secure Works URL:
https://github.com/jasonish/suricata-intel-index/pull/1