### PR TITLE
issue 2449 - handle missing variables - v1

### DIFF
--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -64,6 +64,9 @@ class Configuration:
     def keys(self):
         return self.conf.keys()
 
+    def has_key(self, key):
+        return key in self.conf
+
     def is_true(self, key, truthy=[]):
         if not key in self.conf:
             logger.warning(

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -978,7 +978,7 @@ def _main():
         "-v", "--verbose", action="store_true", default=None,
         help="Be more verbose")
     global_parser.add_argument(
-        "-q", "--quiet", action="store_true", default=False,
+        "-q", "--quiet", action="store_true", default=None,
         help="Be quiet, warning and error messages only")
     global_parser.add_argument(
         "-D", "--data-dir", metavar="<directory>", dest="data_dir",

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -61,6 +61,7 @@ from suricata.update import util
 from suricata.update import sources
 from suricata.update import commands
 from suricata.update import exceptions
+from suricata.update import notes
 
 from suricata.update.version import version
 try:
@@ -802,6 +803,7 @@ def check_vars(suriconf, rulemap):
                 logger.warning(
                     "Rule has unknown source address var and will be disabled: %s: %s" % (
                         var, rule.brief()))
+                notes.address_group_vars.add(var)
                 disable = True
         for var in suricata.update.rule.parse_var_names(
                 rule["dest_addr"]):
@@ -809,6 +811,7 @@ def check_vars(suriconf, rulemap):
                 logger.warning(
                     "Rule has unknown dest address var and will be disabled: %s: %s" % (
                         var, rule.brief()))
+                notes.address_group_vars.add(var)
                 disable = True
         for var in suricata.update.rule.parse_var_names(
                 rule["source_port"]):
@@ -816,6 +819,7 @@ def check_vars(suriconf, rulemap):
                 logger.warning(
                     "Rule has unknown source port var and will be disabled: %s: %s" % (
                         var, rule.brief()))
+                notes.port_group_vars.add(var)
                 disable = True
         for var in suricata.update.rule.parse_var_names(
                 rule["dest_port"]):
@@ -823,6 +827,7 @@ def check_vars(suriconf, rulemap):
                 logger.warning(
                     "Rule has unknown dest port var and will be disabled: %s: %s" % (
                         var, rule.brief()))
+                notes.port_group_vars.add(var)
                 disable = True
 
         if disable:
@@ -1387,6 +1392,7 @@ def _main():
 
     if not args.force and not file_tracker.any_modified():
         logger.info("No changes detected, exiting.")
+        notes.dump_notes()
         return 0
 
     if not test_suricata(suricata_path):
@@ -1403,6 +1409,8 @@ def _main():
             logger.error("Reload command exited with error: %d", rc)
 
     logger.info("Done.")
+
+    notes.dump_notes()
 
     return 0
 

--- a/suricata/update/notes.py
+++ b/suricata/update/notes.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2018 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from __future__ import print_function
+
+import textwrap
+
+# Address group notes.
+address_group_vars = set()
+
+# Port group notes.
+port_group_vars = set()
+
+# Template for missing address-group variable.
+missing_address_group_var_template = """ 
+A rule has been disabled due to the unknown address-group variable
+%(var)s being used. You may want to add this variable to your Suricata
+configuration file.
+"""
+
+# Template for missing port-group variable.
+missing_port_group_var_template = """ 
+A rule has been disabled due to the unknown port-group variable
+%(var)s being used. You may want to add this variable to your Suricata
+configuration file.
+"""
+
+def render_note(note):
+    lines = textwrap.wrap(note.strip().replace("\n", " "))
+    print("* %s" % (lines[0]))
+    for line in lines[1:]:
+        print("  %s" % (line))
+
+def dump_notes():
+    notes = []
+
+    for var in address_group_vars:
+        notes.append(missing_address_group_var_template % {"var": var})
+
+    for var in port_group_vars:
+        notes.append(missing_port_group_var_template % {"var": var})
+
+    if notes:
+        print("\nNotes:\n")
+        for note in notes:
+            render_note(note)
+            print("")

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -212,6 +212,8 @@ def parse(buf, group=None):
 
     header = m.group("header").strip()
 
+    rule = Rule(enabled=enabled, group=group)
+
     # If a decoder rule, the header will be one word.
     if len(header.split(" ")) == 1:
         action = header
@@ -250,24 +252,24 @@ def parse(buf, group=None):
             if states[state] == "action":
                 action = token
             elif states[state] == "proto":
-                proto = token
+                rule["proto"] = token
             elif states[state] == "source_addr":
-                source_addr = token
+                rule["source_addr"] = token
             elif states[state] == "source_port":
-                source_port = token
+                rule["source_port"] = token
             elif states[state] == "direction":
                 direction = token
             elif states[state] == "dest_addr":
-                dest_addr = token
+                rule["dest_addr"] = token
             elif states[state] == "dest_port":
-                dest_port = token
+                rule["dest_port"] = token
 
             state += 1
 
     if action not in actions:
         return None
 
-    rule = Rule(enabled=enabled, action=action, group=group)
+    rule["action"] = action
     rule["direction"] = direction
     rule["header"] = header
 

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -88,7 +88,11 @@ class Rule(dict):
         self["enabled"] = enabled
         self["action"] = action
         self["proto"] = None
+        self["source_addr"] = None
+        self["source_port"] = None
         self["direction"] = None
+        self["dest_addr"] = None
+        self["dest_port"] = None
         self["group"] = group
         self["gid"] = 1
         self["sid"] = None
@@ -448,3 +452,9 @@ def format_sidmsgmap_v2(rule):
         logger.error("Failed to format rule as sid-msg-v2.map: %s" % (
             str(rule)))
         return None
+
+def parse_var_names(var):
+    """ Parse out the variable names from a string. """
+    if var is None:
+        return []
+    return re.findall("\$([\w_]+)", var)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -200,13 +200,17 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
     
         rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] any -> any any (msg:"TEST"; sid:1; rev:1;)""")
         self.assertIsNotNone(rule)
-        
-        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1,2,3] -> any any (msg:"TEST"; sid:1; rev:1;)""")
+        self.assertEqual(rule["source_addr"], "[$HOME_NET, $OTHER_NET]")
+
+        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1, 2, 3] -> any any (msg:"TEST"; sid:1; rev:1;)""")
         self.assertIsNotNone(rule)
+        self.assertEqual(rule["source_port"], "[1, 2, 3]")
 
         rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1,2,3] -> [!$XNET, $YNET] any (msg:"TEST"; sid:1; rev:1;)""")
         self.assertIsNotNone(rule)
+        self.assertEqual(rule["dest_addr"], "[!$XNET, $YNET]")
 
-        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1,2,3] -> [!$XNET, $YNET] [!2200] (msg:"TEST"; sid:1; rev:1;)""")
+        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1,2,3] -> [!$XNET, $YNET] [!2200, 5500] (msg:"TEST"; sid:1; rev:1;)""")
         self.assertIsNotNone(rule)
+        self.assertEqual(rule["dest_port"], "[!2200, 5500]")
         

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -193,3 +193,20 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         self.assertRaises(
             suricata.update.rule.NoEndOfOptionError,
             suricata.update.rule.parse, rule_buf)
+
+    def test_parse_addr_list(self):
+        """Test parsing rules where the addresses and parts are lists with
+        spaces."""
+    
+        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] any -> any any (msg:"TEST"; sid:1; rev:1;)""")
+        self.assertIsNotNone(rule)
+        
+        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1,2,3] -> any any (msg:"TEST"; sid:1; rev:1;)""")
+        self.assertIsNotNone(rule)
+
+        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1,2,3] -> [!$XNET, $YNET] any (msg:"TEST"; sid:1; rev:1;)""")
+        self.assertIsNotNone(rule)
+
+        rule = suricata.update.rule.parse("""alert any [$HOME_NET, $OTHER_NET] [1,2,3] -> [!$XNET, $YNET] [!2200] (msg:"TEST"; sid:1; rev:1;)""")
+        self.assertIsNotNone(rule)
+        


### PR DESCRIPTION
Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2449

If a rule is found to use a variable that is not known to the Suricata configuration, output a warning and disable the rule.

At the end of the `suricata-update` run, output notes giving the user more information about how to resolve the issue.

Example warning logs:
```
27/2/2018 -- 11:10:52 - <Warning> -- Rule has unknown source address var and will be disabled: DC_SERVERS: [1:10002558] [PT OPEN] DCShadow Replication Attempt - DRSUAPI_REPLICA_ADD from non-DC
27/2/2018 -- 11:10:52 - <Warning> -- Rule has unknown dest address var and will be disabled: DC_SERVERS: [1:10002558] [PT OPEN] DCShadow Replication Attempt - DRSUAPI_REPLICA_ADD from non-DC
27/2/2018 -- 11:10:52 - <Warning> -- Rule has unknown source address var and will be disabled: DC_SERVERS: [1:10002557] [PT OPEN] DCShadow Replication Attempt
27/2/2018 -- 11:10:52 - <Warning> -- Rule has unknown dest address var and will be disabled: DC_SERVERS: [1:10002557] [PT OPEN] DCShadow Replication Attempt
27/2/2018 -- 11:10:52 - <Warning> -- Rule has unknown source address var and will be disabled: DC_SERVERS: [1:10002559] [PT OPEN] DCShadow: Fake DC Creation
27/2/2018 -- 11:10:52 - <Warning> -- Rule has unknown dest address var and will be disabled: DC_SERVERS: [1:10002559] [PT OPEN] DCShadow: Fake DC Creation
```

Example note at end of run:
```

Notes:

* A rule has been disabled due to the unknown address-group variable
  DC_SERVERS being used. You may want to add this variable to your
  Suricata configuration file.
```

Additionally fix the --quiet flag to only output warnings and more critical log messages. However, notes will be output regardless of log level.