### PR TITLE
engine: check_output returns encoded byts with python3

### DIFF
--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -37,7 +37,7 @@ SuricataVersion = namedtuple(
 def get_build_info(suricata):
     build_info = {}
     build_info_output = subprocess.check_output([suricata, "--build-info"])
-    for line in build_info_output.split("\n"):
+    for line in build_info_output.decode("utf-8").split("\n"):
         line = line.strip()
         if line.startswith("--prefix"):
             build_info["prefix"] = line.split()[-1].strip()


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:

The _check_output_ function returns encoded bytes with python3, so we need to use decode to be compatible.