### PR TITLE
Ubuntu trusty 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Bundle a copy of the index which can be used if download source for
   the index is not available, and no index was previously
   downloaded. Warnings will be issued.
+- Fix for Python versions prior to 2.7.9 that don't have
+  ssl.create_default_context. For example, Ubuntu Trusty.
 
 ## 1.0.0b1 - 2018-01-19
 - Various fixes for Python 3.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1246,7 +1246,8 @@ def _main():
 
     # Load the Suricata configuration if we can.
     suriconf = None
-    if os.path.exists(config.get("suricata-conf")) and \
+    if config.get("suricata-conf") and \
+       os.path.exists(config.get("suricata-conf")) and \
        suricata_path and os.path.exists(suricata_path):
         logger.info("Loading %s",config.get("suricata-conf"))
         suriconf = suricata.update.engine.Configuration.load(

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -91,14 +91,17 @@ def get(url, fileobj, progress_hook=None):
     user_agent = build_user_agent()
     logger.debug("Setting HTTP user-agent to %s", user_agent)
 
-    ssl_context = ssl.create_default_context()
-
-    if config.get("no-check-certificate"):
-        logger.debug("Disabling SSL/TLS certificate verification.")
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-
-    opener = build_opener(HTTPSHandler(context=ssl_context))
+    try:
+        # Wrap in a try as Python versions prior to 2.7.9 don't have
+        # create_default_context, but some distros have backported it.
+        ssl_context = ssl.create_default_context()
+        if config.get("no-check-certificate"):
+            logger.debug("Disabling SSL/TLS certificate verification.")
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+        opener = build_opener(HTTPSHandler(context=ssl_context))
+    except:
+        opener = build_opener()
 
     opener.addheaders = [
         ("User-Agent", build_user_agent()),


### PR DESCRIPTION
Fix for Ubuntu Trusty which uses Python < 2.7.9 and doesn't have ssl.create_default_context, and by default doesn't verify certificates.

The fix is to attempt to use the newer ssl.create_default_context where we can control certificate validation, but fallback to the default.