### PR TITLE
bundled with suricata fixes - v1

### DIFF
--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -23,6 +23,12 @@ import yaml
 import suricata.update.engine
 from suricata.update.exceptions import ApplicationError
 
+try:
+    from suricata.config import defaults
+    has_defaults = True
+except:
+    has_defaults = False
+
 logger = logging.getLogger()
 
 DEFAULT_DATA_DIRECTORY = "/var/lib/suricata"
@@ -45,7 +51,10 @@ LOCAL_CONF_KEY = "local"
 OUTPUT_KEY = "output"
 DIST_RULE_DIRECTORY_KEY = "dist-rule-directory"
 
-DEFAULT_UPDATE_YAML_PATH = "/etc/suricata/update.yaml"
+if has_defaults:
+    DEFAULT_UPDATE_YAML_PATH = os.path.join(defaults.sysconfdir, "update.yaml")
+else:
+    DEFAULT_UPDATE_YAML_PATH = "/etc/suricata/update.yaml"
 
 DEFAULT_SURICATA_YAML_PATH = [
     "/etc/suricata/suricata.yaml",
@@ -53,9 +62,15 @@ DEFAULT_SURICATA_YAML_PATH = [
     "/etc/suricata/suricata-debian.yaml"
 ]
 
-DEFAULT_DIST_RULE_PATH = [
-    "/etc/suricata/rules",
-]
+if has_defaults:
+    DEFAULT_DIST_RULE_PATH = [
+        defaults.datarulesdir,
+        "/etc/suricata/rules",
+    ]
+else:
+    DEFAULT_DIST_RULE_PATH = [
+        "/etc/suricata/rules",
+    ]
 
 DEFAULT_CONFIG = {
     "disable-conf": "/etc/suricata/disable.conf",

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -967,8 +967,9 @@ def load_sources(suricata_version):
         Fetch().run(url, files)
 
     # Now load local rules.
-    for local in config.get("local"):
-        load_local(local, files)
+    if config.get("local") is not None:
+        for local in config.get("local"):
+            load_local(local, files)
 
     return files
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1130,6 +1130,29 @@ def _main():
     if args.quiet:
         logger.setLevel(logging.WARNING)
 
+    logger.debug("This is suricata-update version %s (rev: %s); Python: %s" % (
+        version, revision, sys.version.replace("\n", "- ")))
+
+    if args.dump_sample_configs:
+        return dump_sample_configs()
+
+    if args.version:
+        print("suricata-update version %s (rev: %s)" % (version, revision))
+        return 0
+
+    if args.help:
+        print(update_parser.format_help())
+        print("""other commands:
+    update-sources             Update the source index
+    list-sources               List available sources
+    enable-source              Enable a source from the index
+    disable-source             Disable an enabled source
+    remove-source              Remove an enabled or disabled source
+    list-enabled-sources       List all enabled sources
+    add-source                 Add a new source by URL
+""")
+        return 0
+
     config.init(args)
     
     # Error out if any reserved/unimplemented arguments were set.
@@ -1143,9 +1166,6 @@ def _main():
         if hasattr(args, arg) and getattr(args, arg):
             logger.error("--%s not implemented", arg)
             return 1
-
-    logger.debug("This is suricata-update version %s (rev: %s); Python: %s" % (
-        version, revision, sys.version.replace("\n", "- ")))
 
     suricata_path = config.get("suricata")
 
@@ -1190,26 +1210,6 @@ def _main():
         elif args.subcommand != "update":
             logger.error("Unknown command: %s", args.subcommand)
             return 1
-
-    if args.dump_sample_configs:
-        return dump_sample_configs()
-
-    if args.version:
-        print("suricata-update version %s (rev: %s)" % (version, revision))
-        return 0
-
-    if args.help:
-        print(update_parser.format_help())
-        print("""other commands:
-    update-sources             Update the source index
-    list-sources               List available sources
-    enable-source              Enable a source from the index
-    disable-source             Disable an enabled source
-    remove-source              Remove an enabled or disabled source
-    list-enabled-sources       List all enabled sources
-    add-source                 Add a new source by URL
-""")
-        return 0
 
     # If --no-ignore was provided, clear any ignores provided in the
     # config.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -980,6 +980,8 @@ def copytree_ignore_backup(src, names):
 def _main():
     global args
 
+    default_update_yaml = config.DEFAULT_UPDATE_YAML_PATH
+
     global_parser = argparse.ArgumentParser(add_help=False)
     global_parser.add_argument(
         "-v", "--verbose", action="store_true", default=None,
@@ -992,7 +994,7 @@ def _main():
         help="Data directory (default: /var/lib/suricata)")
     global_parser.add_argument(
         "-c", "--config", metavar="<filename>",
-        help="configuration file (default: /etc/suricata/update.yaml)")
+        help="configuration file (default: %s)" %(default_update_yaml))
     global_parser.add_argument(
         "--suricata-conf", metavar="<filename>",
         help="configuration file (default: /etc/suricata/suricata.yaml)")


### PR DESCRIPTION
Attempt to get default directories from the defaults.py module that suricata will drop when compiled (with Python support). In order for suricata-update to find the defaults.py, it must be installed as bundled with Suricata, or installed into the same prefix. The main idea here is to better support the use case when bundled.

Plus some other minor fixups.