### PR TITLE
Support for multiple conditions to match a rule

### DIFF
--- a/doc/update.rst
+++ b/doc/update.rst
@@ -228,6 +228,14 @@ are allowed::
   filename:rules/*deleted*
   filename:*/emerging-dos.rules
 
+Multi Matching
+--------------
+
+The above matching methods can also be combined::
+
+  multi:filename:*/emerging-scan.rule;re:nmap;
+  multi:group:emerging-web_specific_apps;re:wordpress;re:cve[-,]201[6-9];
+
 Modifying Rules
 ---------------
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -224,6 +224,35 @@ class ReRuleMatcher(object):
                 pass
         return None
 
+class MultiRuleMatcher(object):
+    """Matcher that build a container around other matchers. All childmatchers have to match for a true match.
+    Config syntax is "multi:<chlild1>;<child2>;<clildN>"."""
+
+    def __init__(self, childmatchers):
+        self.childmatchers = childmatchers
+
+    def match(self, rule):
+        for matcher in self.childmatchers:
+            if not matcher.match(rule):
+                return False
+        return True
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.startswith("multi:"):
+            try:
+                logger.debug("Parsing multi matcher: %s" % (buf))
+                childmatcherstrs = filter(None,buf.split(":", 1)[1].strip().split(";"))
+                childmatchers = []
+                for childstr in childmatcherstrs:
+                    matcher = parse_rule_match(childstr.strip())
+                    if matcher:
+                        childmatchers.append(matcher)
+                return cls(childmatchers)
+            except:
+                pass
+        return None
+
 class ModifyRuleFilter(object):
     """Filter to modify an idstools rule object.
 
@@ -417,6 +446,10 @@ def parse_rule_match(match):
         return matcher
 
     matcher = GroupMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = MultiRuleMatcher.parse(match)
     if matcher:
         return matcher
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [xI have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

[redmine issue 2509](https://redmine.openinfosecfoundation.org/issues/2509):

Describe changes:

This adds support to specify multiple conditions to match a rule in
{enable,disable}.conf.

Syntax:
multi:<match_condition1>;<match_conditios2>;...<match_conditionN>;

Example:
Enable all rules including the term "nmap" bust just from the "emerging-scan.rules" file.

multi:filename:rule/emerging-scan.rules; re:nmap;
