### PR TITLE
Quote reload command

### DIFF
--- a/doc/update.rst
+++ b/doc/update.rst
@@ -160,7 +160,7 @@ Options
    A command to run after the rules have been updated; will not run if
    no change to the output files was made.  For example::
 
-     --reload-command=sudo kill -USR2 $(cat /var/run/suricata.pid)
+     --reload-command='sudo kill -USR2 $(cat /var/run/suricata.pid)'
 
    will tell Suricata to reload its rules.
 


### PR DESCRIPTION
suricata-update throws error if the command is not quoted.
```
suricata-update: error: unrecognized arguments: kill -USR2
```

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x ] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x ] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

