### PR TITLE
Use assertEqual instead of deprecated assertEquals

### DIFF
--- a/tests/test_classificationmap.py
+++ b/tests/test_classificationmap.py
@@ -26,21 +26,21 @@ class ClassificationMapTestCase(unittest.TestCase):
         m = ClassificationMap(open(self.test_filename))
 
         # Classifications are indexed at 1.
-        self.assertEquals(None, m.get(0))
+        self.assertEqual(None, m.get(0))
 
         c = m.get(1)
-        self.assertEquals("not-suspicious", c["name"])
-        self.assertEquals("Not Suspicious Traffic", c["description"])
-        self.assertEquals(3, c["priority"])
+        self.assertEqual("not-suspicious", c["name"])
+        self.assertEqual("Not Suspicious Traffic", c["description"])
+        self.assertEqual(3, c["priority"])
 
         c = m.get(34)
-        self.assertEquals("default-login-attempt", c["name"])
-        self.assertEquals("Attempt to Login By a Default Username and Password",
+        self.assertEqual("default-login-attempt", c["name"])
+        self.assertEqual("Attempt to Login By a Default Username and Password",
                           c["description"])
-        self.assertEquals(2, c["priority"])
+        self.assertEqual(2, c["priority"])
 
         c = m.get_by_name("unknown")
         self.assertTrue(c is not None)
-        self.assertEquals("unknown", c["name"])
-        self.assertEquals("Unknown Traffic", c["description"])
-        self.assertEquals(3, c["priority"])
+        self.assertEqual("unknown", c["name"])
+        self.assertEqual("Unknown Traffic", c["description"])
+        self.assertEqual(3, c["priority"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,21 +72,21 @@ class ThresholdProcessorTestCase(unittest.TestCase):
         processor = main.ThresholdProcessor()
 
         line = "suppress re:java"
-        self.assertEquals("java", processor.extract_regex(line))
+        self.assertEqual("java", processor.extract_regex(line))
         
         line = 'suppress re:"vulnerable java version"'
-        self.assertEquals(
+        self.assertEqual(
             "vulnerable java version", processor.extract_regex(line))
 
         line = "suppress re:java, track <by_src|by_dst>, ip <ip|subnet>"
-        self.assertEquals("java", processor.extract_regex(line))
+        self.assertEqual("java", processor.extract_regex(line))
     
         line = 'suppress re:"vulnerable java version", track <by_src|by_dst>, ip <ip|subnet>'
-        self.assertEquals(
+        self.assertEqual(
             "vulnerable java version", processor.extract_regex(line))
 
         line = 'threshold re:"vulnerable java version", type threshold, track by_dst, count 1, seconds 10'
-        self.assertEquals(
+        self.assertEqual(
             "vulnerable java version", processor.extract_regex(line))
 
     def test_replace(self):
@@ -94,17 +94,17 @@ class ThresholdProcessorTestCase(unittest.TestCase):
         rule = suricata.update.rule.parse(rule_string)
 
         line = "suppress re:windows"
-        self.assertEquals(
+        self.assertEqual(
             "suppress gen_id 1, sig_id 2020757",
             self.processor.replace(line, rule))
 
         line = 'threshold re:"ET MALWARE Windows", type threshold, ' \
                'track by_dst, count 1, seconds 10'
-        self.assertEquals("threshold gen_id 1, sig_id 2020757, type threshold, track by_dst, count 1, seconds 10", self.processor.replace(line, rule))
+        self.assertEqual("threshold gen_id 1, sig_id 2020757, type threshold, track by_dst, count 1, seconds 10", self.processor.replace(line, rule))
 
         line = 'threshold re:malware, type threshold, track by_dst, count 1, ' \
                'seconds 10'
-        self.assertEquals(
+        self.assertEqual(
             "threshold gen_id 1, sig_id 2020757, type threshold, "
             "track by_dst, count 1, seconds 10",
             self.processor.replace(line, rule))
@@ -200,7 +200,7 @@ class DropRuleFilterTestCase(unittest.TestCase):
 
         drop_filter = main.DropRuleFilter(id_matcher)
         rule1 = drop_filter.filter(rule0)
-        self.assertEquals("drop", rule1.action)
+        self.assertEqual("drop", rule1.action)
         self.assertTrue(rule1.enabled)
         self.assertTrue(str(rule1).startswith("drop"))
 
@@ -212,7 +212,7 @@ class DropRuleFilterTestCase(unittest.TestCase):
 
         drop_filter = main.DropRuleFilter(id_matcher)
         rule1 = drop_filter.filter(rule0)
-        self.assertEquals("drop", rule1.action)
+        self.assertEqual("drop", rule1.action)
         self.assertFalse(rule1.enabled)
         self.assertTrue(str(rule1).startswith("# drop"))
         

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -31,13 +31,13 @@ class GroupMatcherTestCase(unittest.TestCase):
     def test_match(self):
         rule = suricata.update.rule.parse(self.rule_string, "rules/malware.rules")
         matcher = main.parse_rule_match("group: malware.rules")
-        self.assertEquals(
+        self.assertEqual(
             matcher.__class__, suricata.update.main.GroupMatcher)
         self.assertTrue(matcher.match(rule))
 
         # Test match of just the group basename.
         matcher = main.parse_rule_match("group: malware")
-        self.assertEquals(
+        self.assertEqual(
             matcher.__class__, suricata.update.main.GroupMatcher)
         self.assertTrue(matcher.match(rule))
 
@@ -48,7 +48,7 @@ class FilenameMatcherTestCase(unittest.TestCase):
     def test_match(self):
         rule = suricata.update.rule.parse(self.rule_string, "rules/trojan.rules")
         matcher = main.parse_rule_match("filename: */trojan.rules")
-        self.assertEquals(
+        self.assertEqual(
             matcher.__class__, suricata.update.main.FilenameMatcher)
         self.assertTrue(matcher.match(rule))
 
@@ -60,11 +60,11 @@ class LoadMatchersTestCase(unittest.TestCase):
 re:.# This is a comment*
 1:100 # Trailing comment.
 """))
-        self.assertEquals(
+        self.assertEqual(
             matchers[0].__class__, suricata.update.main.FilenameMatcher)
-        self.assertEquals(
+        self.assertEqual(
             matchers[1].__class__, suricata.update.main.ReRuleMatcher)
-        self.assertEquals(
+        self.assertEqual(
             matchers[2].__class__, suricata.update.main.IdRuleMatcher)
 
 class IdRuleMatcherTestCase(unittest.TestCase):
@@ -72,27 +72,27 @@ class IdRuleMatcherTestCase(unittest.TestCase):
     def test_parse_single_sid(self):
         matcher = main.IdRuleMatcher.parse("123")
         self.assertIsNotNone(matcher)
-        self.assertEquals(1, len(matcher.signatureIds))
+        self.assertEqual(1, len(matcher.signatureIds))
 
     def test_parse_single_gidsid(self):
         matcher = main.IdRuleMatcher.parse("1:123")
         self.assertIsNotNone(matcher)
-        self.assertEquals(1, len(matcher.signatureIds))
+        self.assertEqual(1, len(matcher.signatureIds))
 
     def test_parse_multi_sid(self):
         matcher = main.IdRuleMatcher.parse("1,2,3")
         self.assertIsNotNone(matcher)
-        self.assertEquals(3, len(matcher.signatureIds))
+        self.assertEqual(3, len(matcher.signatureIds))
 
     def test_parse_multi_gidsid(self):
         matcher = main.IdRuleMatcher.parse("1:1000,2:2000,    3:3000, 4:4000")
         self.assertIsNotNone(matcher)
-        self.assertEquals(4, len(matcher.signatureIds))
+        self.assertEqual(4, len(matcher.signatureIds))
 
     def test_parse_multi_mixed(self):
         matcher = main.IdRuleMatcher.parse("1:1000, 2000, 3:3000, 4000")
         self.assertIsNotNone(matcher)
-        self.assertEquals(4, len(matcher.signatureIds))
+        self.assertEqual(4, len(matcher.signatureIds))
 
     def test_parse_invalid(self):
         matcher = main.IdRuleMatcher.parse("a")

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -40,35 +40,35 @@ class RuleTestCase(unittest.TestCase):
         self.assertEqual(rule.metadata[0], "stage")
         self.assertEqual(rule.metadata[1], "hostile_download")
         self.assertEqual(len(rule.flowbits), 2)
-        self.assertEquals(rule.flowbits[0], "isset,somebit")
-        self.assertEquals(rule.flowbits[1], "unset,otherbit")
-        self.assertEquals(rule.classtype, "trojan-activity")
+        self.assertEqual(rule.flowbits[0], "isset,somebit")
+        self.assertEqual(rule.flowbits[1], "unset,otherbit")
+        self.assertEqual(rule.classtype, "trojan-activity")
 
     def test_disable_rule(self):
         rule_buf = """# alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)"""
         rule = suricata.update.rule.parse(rule_buf)
         self.assertFalse(rule.enabled)
-        self.assertEquals(rule.raw, """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
-        self.assertEquals(str(rule), rule_buf)
+        self.assertEqual(rule.raw, """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
+        self.assertEqual(str(rule), rule_buf)
 
     def test_parse_rule_double_commented(self):
         rule_buf = """## alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)"""
         rule = suricata.update.rule.parse(rule_buf)
         self.assertFalse(rule.enabled)
-        self.assertEquals(rule.raw, """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
+        self.assertEqual(rule.raw, """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
 
     def test_parse_rule_comments_and_spaces(self):
         rule_buf = """## #alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)"""
         rule = suricata.update.rule.parse(rule_buf)
         self.assertFalse(rule.enabled)
-        self.assertEquals(rule.raw, """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
+        self.assertEqual(rule.raw, """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
 
     def test_toggle_rule(self):
         rule_buf = """# alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)"""
         rule = suricata.update.rule.parse(rule_buf)
         self.assertFalse(rule.enabled)
         rule.enabled = True
-        self.assertEquals(str(rule), """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
+        self.assertEqual(str(rule), """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
 
     def test_parse_fileobj(self):
         rule_buf = ("""# alert tcp $HOME_NET any -> $EXTERNAL_NET any """
@@ -78,7 +78,7 @@ class RuleTestCase(unittest.TestCase):
             fileobj.write(u"%s\n" % rule_buf)
         fileobj.seek(0)
         rules = suricata.update.rule.parse_fileobj(fileobj)
-        self.assertEquals(2, len(rules))
+        self.assertEqual(2, len(rules))
 
     def test_parse_file(self):
         rule_buf = ("""# alert tcp $HOME_NET any -> $EXTERNAL_NET any """
@@ -88,7 +88,7 @@ class RuleTestCase(unittest.TestCase):
             tmp.write(("%s\n" % rule_buf).encode())
         tmp.flush()
         rules = suricata.update.rule.parse_file(tmp.name)
-        self.assertEquals(2, len(rules))
+        self.assertEqual(2, len(rules))
 
     def test_parse_file_with_unicode(self):
         rules = suricata.update.rule.parse_file("./tests/rule-with-unicode.rules")
@@ -96,7 +96,7 @@ class RuleTestCase(unittest.TestCase):
     def test_parse_decoder_rule(self):
         rule_string = """alert ( msg:"DECODE_NOT_IPV4_DGRAM"; sid:1; gid:116; rev:1; metadata:rule-type decode; classtype:protocol-command-decode;)"""
         rule = suricata.update.rule.parse(rule_string)
-        self.assertEquals(rule["direction"], None)
+        self.assertEqual(rule["direction"], None)
 
     def test_multiline_rule(self):
         rule_string = u"""
@@ -104,30 +104,30 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
       app-layer-event:dnp3.flooded; sid:2200104; rev:1;)
 """
         rules = suricata.update.rule.parse_fileobj(io.StringIO(rule_string))
-        self.assertEquals(len(rules), 1)
+        self.assertEqual(len(rules), 1)
 
     def test_parse_nomsg(self):
         rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)
-        self.assertEquals("", rule["msg"])
+        self.assertEqual("", rule["msg"])
 
     def test_add_option(self):
         rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string, "local.rules")
         rule = suricata.update.rule.add_option(
             rule, "msg", "\"This is a test description.\"", 0)
-        self.assertEquals("This is a test description.", rule["msg"])
-        self.assertEquals("local.rules", rule["group"])
+        self.assertEqual("This is a test description.", rule["msg"])
+        self.assertEqual("local.rules", rule["group"])
 
     def test_remove_option(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST MESSAGE"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string, "local.rules")
 
         rule = suricata.update.rule.remove_option(rule, "msg")
-        self.assertEquals("", rule["msg"])
+        self.assertEqual("", rule["msg"])
 
         rule = suricata.update.rule.remove_option(rule, "classtype")
-        self.assertEquals(None, rule["classtype"])
+        self.assertEqual(None, rule["classtype"])
 
     def test_remove_tag_option(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST RULE"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
@@ -138,7 +138,7 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
     def test_scratch(self):
         rule_string = """alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"ET CURRENT_EVENTS Request to .in FakeAV Campaign June 19 2012 exe or zip"; flow:established,to_server; content:"setup."; fast_pattern:only; http_uri; content:".in|0d 0a|"; flowbits:isset,somebit; flowbits:unset,otherbit; http_header; pcre:"/\/[a-f0-9]{16}\/([a-z0-9]{1,3}\/)?setup\.(exe|zip)$/U"; pcre:"/^Host\x3a\s.+\.in\r?$/Hmi"; metadata:stage,hostile_download; reference:url,isc.sans.edu/diary/+Vulnerabilityqueerprocessbrittleness/13501; classtype:trojan-activity; sid:2014929; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)
-        self.assertEquals(rule_string, str(rule))
+        self.assertEqual(rule_string, str(rule))
 
         options = []
         for option in rule["options"]:
@@ -153,13 +153,13 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         print("%s" % rule_string)
         print("%s" % reassembled)
 
-        self.assertEquals(rule_string, reassembled)
+        self.assertEqual(rule_string, reassembled)
         
     def test_parse_message_with_semicolon(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST RULE\; and some"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)
         self.assertIsNotNone(rule)
-        self.assertEquals(rule.msg, "TEST RULE\; and some")
+        self.assertEqual(rule.msg, "TEST RULE\; and some")
 
         # Look for the expected content.
         found=False
@@ -173,7 +173,7 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule_string = u"""alert tcp 93.174.88.0/21 any -> $HOME_NET any (msg:"SN: Inbound TCP traffic from suspect network (AS29073 - NL)"; flags:S; reference:url,https://suspect-networks.io/networks/cidr/13/; threshold: type limit, track by_dst, seconds 30, count 1; classtype:misc-attack; sid:71918985; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)
         self.assertIsNotNone(rule)
-        self.assertEquals(
+        self.assertEqual(
             rule.msg,
             "SN: Inbound TCP traffic from suspect network (AS29073 - NL)")
 

--- a/tests/test_signaturemap.py
+++ b/tests/test_signaturemap.py
@@ -27,15 +27,15 @@ class SignatureMapTestCase(unittest.TestCase):
 
         sig = sigmap.get(1, 1)
         self.assertTrue(sig is not None)
-        self.assertEquals(1, sig["gid"])
-        self.assertEquals(1, sig["sid"])
-        self.assertEquals("snort general alert", sig["msg"])
+        self.assertEqual(1, sig["gid"])
+        self.assertEqual(1, sig["sid"])
+        self.assertEqual("snort general alert", sig["msg"])
 
         sig = sigmap.get(139, 1)
         self.assertTrue(sig is not None)
-        self.assertEquals(139, sig["gid"])
-        self.assertEquals(1, sig["sid"])
-        self.assertEquals(
+        self.assertEqual(139, sig["gid"])
+        self.assertEqual(1, sig["sid"])
+        self.assertEqual(
             "sensitive_data: sensitive data global threshold exceeded",
             sig["msg"])
 
@@ -47,21 +47,21 @@ class SignatureMapTestCase(unittest.TestCase):
         # Get a basic signature.
         sig = sigmap.get(1, 2000356)
         self.assertTrue(sig is not None)
-        self.assertEquals(1, sig["gid"])
-        self.assertEquals(2000356, sig["sid"])
-        self.assertEquals("ET POLICY IRC connection", sig["msg"])
-        self.assertEquals(len(sig["ref"]), 1)
-        self.assertEquals("url,doc.emergingthreats.net/2000356", sig["ref"][0])
+        self.assertEqual(1, sig["gid"])
+        self.assertEqual(2000356, sig["sid"])
+        self.assertEqual("ET POLICY IRC connection", sig["msg"])
+        self.assertEqual(len(sig["ref"]), 1)
+        self.assertEqual("url,doc.emergingthreats.net/2000356", sig["ref"][0])
 
         # Try again but with a gid of 3.
-        self.assertEquals(sig, sigmap.get(3, 2000356))
+        self.assertEqual(sig, sigmap.get(3, 2000356))
 
         # This signature has multiple refs.
         sig = sigmap.get(1, 2000373)
-        self.assertEquals(3, len(sig["ref"]))
+        self.assertEqual(3, len(sig["ref"]))
 
         sig = sigmap.get(1, 71918985)
-        self.assertEquals(
+        self.assertEqual(
             "SN: Inbound TCP traffic from suspect network (AS29073 - NL)",
             sig["msg"])
 
@@ -71,11 +71,11 @@ class SignatureMapTestCase(unittest.TestCase):
         sigmap.load_signature_map(open("tests/sid-msg-v2.map"))
 
         sig = sigmap.get(1, 2495)
-        self.assertEquals(1, sig["gid"])
-        self.assertEquals(2495, sig["sid"])
-        self.assertEquals("misc-attack", sig["classification"])
-        self.assertEquals(0, sig["priority"])
-        self.assertEquals(
+        self.assertEqual(1, sig["gid"])
+        self.assertEqual(2495, sig["sid"])
+        self.assertEqual("misc-attack", sig["classification"])
+        self.assertEqual(0, sig["priority"])
+        self.assertEqual(
             "GPL NETBIOS SMB DCEPRC ORPCThis request flood attempt",
             sig["msg"])
-        self.assertEquals(4, len(sig["ref"]))
+        self.assertEqual(4, len(sig["ref"]))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -28,6 +28,6 @@ class Md5TestCase(unittest.TestCase):
         test_file = tempfile.NamedTemporaryFile()
         test_file.write(b"This is a test.")
         test_file.flush()
-        self.assertEquals(
+        self.assertEqual(
             "120ea8a25e5d487bf68b5f7096440019",
             util.md5_hexdigest(test_file.name))


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: None

Describe changes:
Replace the use of `assertEquals` in all places with `assertEqual` as the former was deprecated in https://bugs.python.org/issue9424
`assertEqual` goes well with Python 2.7 alongwith Python 3.x so this does not break any existing test cases.