### PR TITLE
Add Python 3.7 to tox configurations

### DIFF
--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 commands = python ./tests/integration_tests.py

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: None

Describe changes:
Current tox configuration was missing Python 3.7 because of which tests were
never run for a Python 3.7 environment. Fix that by adding py37 to the configurations.

This PR is a revision of #45 having the requested changes.