### PR TITLE
Add --free argument to list-sources command

### DIFF
--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -27,9 +27,11 @@ from suricata.update import exceptions
 logger = logging.getLogger()
 
 def register(parser):
+    parser.add_argument("--free", action="store_true", default=False, help="List all freely available sources")
     parser.set_defaults(func=list_sources)
 
 def list_sources():
+    free_only = config.args().free
     if not sources.source_index_exists(config):
         logger.info("No source index found, running update-sources")
         try:
@@ -38,6 +40,9 @@ def list_sources():
             logger.warning("%s: will use bundled index.", err)
     index = sources.load_source_index(config)
     for name, source in index.get_sources().items():
+        is_free = source.get("subscribe-url")
+        if free_only and not is_free:
+            continue
         print("%s: %s" % (util.bright_cyan("Name"), util.bright_magenta(name)))
         print("  %s: %s" % (
             util.bright_cyan("Vendor"), util.bright_magenta(source["vendor"])))


### PR DESCRIPTION
Add the functionality of being able to list only the free sources with
the `list-sources` command. This patch differentiates a free source from
a non-free source based on the availability of "subscription-url" for a
particular source.

This argument is also available in the help section of `list-sources`
command.

```
$./suricata-update list-sources -h
usage: suricata-update list-sources [-h] [-v] [-q] [-D <directory>]
                                    [-c <filename>]
                                    [--suricata-conf <filename>]
                                    [--suricata <path>]
                                    [--suricata-version <version>]
                                    [--user-agent <user-agent>]
                                    [--no-check-certificate] [-V] [--free]

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Be more verbose
  -q, --quiet           Be quiet, warning and error messages only
  -D <directory>, --data-dir <directory>
                        Data directory (default: /var/lib/suricata)
  -c <filename>, --config <filename>
                        configuration file (default:
                        /etc/suricata/update.yaml)
  --suricata-conf <filename>
                        configuration file (default:
                        /etc/suricata/suricata.yaml)
  --suricata <path>     Path to Suricata program
  --suricata-version <version>
                        Override Suricata version
  --user-agent <user-agent>
                        Set custom user-agent string
  --no-check-certificate
                        Disable server SSL/TLS certificate verification
  -V, --version         Display version
  --free                List all freely available sources
```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2641