### PR TITLE
update classification.conf to Suricata 4.1 style - v1

### DIFF
--- a/tests/classification.config
+++ b/tests/classification.config
@@ -1,8 +1,7 @@
+
 #
 # config classification:shortname,short description,priority
 #
-
-#Traditional classifications. These will be replaced soon
 
 config classification: not-suspicious,Not Suspicious Traffic,3
 config classification: unknown,Unknown Traffic,3
@@ -17,25 +16,36 @@ config classification: unsuccessful-user,Unsuccessful User Privilege Gain,1
 config classification: successful-user,Successful User Privilege Gain,1
 config classification: attempted-admin,Attempted Administrator Privilege Gain,1
 config classification: successful-admin,Successful Administrator Privilege Gain,1
+
+# NEW CLASSIFICATIONS
 config classification: rpc-portmap-decode,Decode of an RPC Query,2
-config classification: shellcode-detect,Executable Code was Detected,1
-config classification: string-detect,A Suspicious String was Detected,3
-config classification: suspicious-filename-detect,A Suspicious Filename was Detected,2
-config classification: suspicious-login,An Attempted Login Using a Suspicious Username was Detected,2
-config classification: system-call-detect,A System Call was Detected,2
-config classification: tcp-connection,A TCP Connection was Detected,4
-config classification: trojan-activity,A Network Trojan was Detected, 1
-config classification: unusual-client-port-connection,A Client was Using an Unusual Port,2
+config classification: shellcode-detect,Executable code was detected,1
+config classification: string-detect,A suspicious string was detected,3
+config classification: suspicious-filename-detect,A suspicious filename was detected,2
+config classification: suspicious-login,An attempted login using a suspicious username was detected,2
+config classification: system-call-detect,A system call was detected,2
+config classification: tcp-connection,A TCP connection was detected,4
+config classification: trojan-activity,A Network Trojan was detected, 1
+config classification: unusual-client-port-connection,A client was using an unusual port,2
 config classification: network-scan,Detection of a Network Scan,3
 config classification: denial-of-service,Detection of a Denial of Service Attack,2
-config classification: non-standard-protocol,Detection of a Non-Standard Protocol or Event,2
+config classification: non-standard-protocol,Detection of a non-standard protocol or event,2
 config classification: protocol-command-decode,Generic Protocol Command Decode,3
-config classification: web-application-activity,Access to a Potentially Vulnerable Web Application,2
+config classification: web-application-activity,access to a potentially vulnerable web application,2
 config classification: web-application-attack,Web Application Attack,1
 config classification: misc-activity,Misc activity,3
 config classification: misc-attack,Misc Attack,2
 config classification: icmp-event,Generic ICMP event,3
-config classification: inappropriate-content,Inappropriate Content was Detected,1
+config classification: kickass-porn,SCORE! Get the lotion!,1
 config classification: policy-violation,Potential Corporate Privacy Violation,1
-config classification: default-login-attempt,Attempt to Login By a Default Username and Password,2
+config classification: default-login-attempt,Attempt to login by a default username and password,2
 
+# Update
+config classification: targeted-activity,Targeted Malicious Activity was Detected,1
+config classification: exploit-kit,Exploit Kit Activity Detected,1
+config classification: external-ip-check,Device Retrieving External IP Address Detected,2
+config classification: domain-c2,Domain Observed Used for C2 Detected,1
+config classification: pup-activity,Possibly Unwanted Program Detected,2
+config classification: credential-theft,Successful Credential Theft Detected,1
+config classification: social-engineering,Possible Social Engineering Attempted,2
+config classification: coin-mining,Crypto Currency Mining Activity Detected,2

--- a/tests/test_classificationmap.py
+++ b/tests/test_classificationmap.py
@@ -35,7 +35,7 @@ class ClassificationMapTestCase(unittest.TestCase):
 
         c = m.get(34)
         self.assertEqual("default-login-attempt", c["name"])
-        self.assertEqual("Attempt to Login By a Default Username and Password",
+        self.assertEqual("Attempt to login by a default username and password",
                           c["description"])
         self.assertEqual(2, c["priority"])
 


### PR DESCRIPTION
This is a sync from Travis to make the test classification.config match the current style used in Suricata.

Oops, should not have done this on the OISF repo, but leaving as-is since already done.