### PR TITLE
Remove empty User Agent request header

### DIFF
--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -54,8 +54,9 @@ def set_user_agent_suricata_version(version):
 def build_user_agent():
     params = []
 
-    if custom_user_agent is not None:
-        return custom_user_agent
+    if custom_user_agent and len(custom_user_agent.strip()) == 0:
+        return None
+    return custom_user_agent
 
     uname_system = platform.uname()[0]
 
@@ -103,10 +104,11 @@ def get(url, fileobj, progress_hook=None):
     except:
         opener = build_opener()
 
-    opener.addheaders = [
-        ("User-Agent", build_user_agent()),
-    ]
-
+    if user_agent:
+        opener.addheaders = [("User-Agent", user_agent),]
+    else:
+        opener.addheaders = [(header, value) for header,
+                             value in opener.addheaders if header.lower() != "user-agent"]
     remote = opener.open(url)
     info = remote.info()
     try:


### PR DESCRIPTION
`suricata-update` sends a User Agent as a part of the request header to
get some basic information about the user system like the suricata-update
version, python version, etc. However, some users do not like this
behavior and are facililated with a `--user-agent` option whereby they
can modify the `User-Agent` header to a custom string. Although, in some
cases, it has been observed that the `User-Agent` header can be set to
nothing. In some other cases, users wish to set it to an empty string.

Example:

```
$ ./bin/suricata-update update-sources --user-agent "  "
```

generates request headers like,

```
Accept-Encoding: identity
Host: XXX
User-Agent:
Connection: close
```

which makes `User-Agent` header quite redundant.

Remove the header if it is set to a string that evaluates to nothing.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: None

This is a rework of #49 