### PR TITLE
Fix --test-command; logging fixups - v1

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -870,11 +870,11 @@ def test_suricata(suricata_path):
             test_command))
         env = {
             "SURICATA_PATH": suricata_path,
-            "OUTPUT_DIR": config.get("output"),
+            "OUTPUT_DIR": config.get_output_dir(),
         }
         if not config.get("no-merge"):
             env["OUTPUT_FILENAME"] = os.path.join(
-                config.get("output"), DEFAULT_OUTPUT_RULE_FILENAME)
+                config.get_output_dir(), DEFAULT_OUTPUT_RULE_FILENAME)
         rc = subprocess.Popen(test_command, shell=True, env=env).wait()
         if rc != 0:
             return False

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -785,7 +785,11 @@ class FileTracker:
 
     def add(self, filename):
         checksum = self.md5(filename)
-        logger.debug("Recording file %s with hash '%s'.", filename, checksum)
+        if not checksum:
+            logger.debug("Recording new file %s" % (filename))
+        else:
+            logger.debug("Recording existing file %s with hash '%s'.",
+                filename, checksum)
         self.hashes[filename] = checksum
 
     def md5(self, filename):

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -997,6 +997,17 @@ def copytree_ignore_backup(src, names):
     """ Returns files to ignore when doing a backup of the rules. """
     return [".cache"]
 
+def check_output_directory(output_dir):
+    """ Check that the output directory exists, creating it if it doesn't. """
+    if not os.path.exists(output_dir):
+        logger.info("Creating directory %s." % (output_dir))
+        try:
+            os.makedirs(output_dir, mode=0o770)
+        except Exception as err:
+            raise exceptions.ApplicationError(
+                "Failed to create directory %s: %s" % (
+                    output_dir, err))
+
 def _main():
     global args
 
@@ -1362,15 +1373,8 @@ def _main():
     # Fixup flowbits.
     resolve_flowbits(rulemap, disabled_rules)
 
-    # Check that output directory exists.
-    if not os.path.exists(config.get_output_dir()):
-        try:
-            os.makedirs(config.get_output_dir(), mode=0o770)
-        except Exception as err:
-            logger.error(
-                "Output directory does not exist and could not be created: %s",
-                config.get_output_dir())
-            return 1
+    # Check that output directory exists, creating it if needed.
+    check_output_directory(config.get_output_dir())
 
     # Check that output directory is writable.
     if not os.access(config.get_output_dir(), os.W_OK):


### PR DESCRIPTION
Suricata-Update would fail on a custom --test-command when setting up the environment if no --output directory was explicitly passed. Fix this by using the proper way to get the output directory.

Based on feedback from @victorjulien, provide a better log message when failing to create the data directory, include the OS error. It will most likely be a permission denied error.

Lastly, a very minor log fixup in debug mode that was confusing to me when recording the hashes of new files in a downloaded tarball. Log them as being new instead of having a previous hash of "".
