### PR TITLE
Rules filename arg

### DIFF
--- a/doc/update.rst
+++ b/doc/update.rst
@@ -24,6 +24,12 @@ Options
 
    Default: */var/lib/suricata/rules*
 
+.. option:: -r, --output-rule-filename
+
+   Name of the output rules file. 
+
+   Default: *suricata.rules*
+
 .. option:: --force
 
    Force remote rule files to be downloaded if they otherwise wouldn't

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1028,6 +1028,9 @@ def _main():
         "--user-agent", metavar="<user-agent>",
         help="Set custom user-agent string")
     global_parser.add_argument(
+        "-r","--output-rule-filename", metavar="<filename>",
+        help="Filename of output rules file (default: suricata.rules)")
+    global_parser.add_argument(
         "--no-check-certificate", action="store_true", default=None,
         help="Disable server SSL/TLS certificate verification")
     global_parser.add_argument(
@@ -1263,6 +1266,12 @@ def _main():
     if drop_conf_filename and os.path.exists(drop_conf_filename):
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
+
+    # Load user provided output rules filename
+    rule_filename = config.get("output-rule-filename")
+    if rule_filename:
+        logger.info("Setting output rule filename to %s", rule_filename)
+        DEFAULT_OUTPUT_RULE_FILENAME = rule_filename
 
     # Load the Suricata configuration if we can.
     suriconf = None


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/2659

Describe changes:
-  updated documentation
- added new argument that defines the ouput rules filename

Purpose:

when managing multiple rules input files that are going to be put through suricata-update filter, the output rules file is always suricata.rules. Sometimes there is a preference for the filtered rules file input to retain the same output rules filename, and so this will help. 