### PR TITLE
Abolish empty User-Agent

### DIFF
--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -92,6 +92,10 @@ _config = {}
 # The filename the config was read from, if any.
 filename = None
 
+def has(key):
+    """Return true if a configuration key exists."""
+    return key in _config
+
 def set(key, value):
     """Set a configuration value."""
     _config[key] = value
@@ -167,7 +171,6 @@ def init(args):
                 filename = DEFAULT_UPDATE_YAML_PATH
 
     # Apply command line arguments to the config.
-
     for arg in vars(args):
         if arg == "local":
             for local in args.local:
@@ -176,7 +179,7 @@ def init(args):
         elif arg == "data_dir" and args.data_dir:
             logger.debug("Setting data directory to %s", args.data_dir)
             _config[DATA_DIRECTORY_KEY] = args.data_dir
-        elif getattr(args, arg):
+        elif getattr(args, arg) is not None:
             key = arg.replace("_", "-")
             val = getattr(args, arg)
             logger.debug("Setting configuration value %s -> %s", key, val)

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1227,12 +1227,6 @@ def _main():
     # User-Agent.
     suricata.update.net.set_user_agent_suricata_version(suricata_version.full)
 
-    # Load custom user-agent-string.
-    user_agent = config.get("user-agent")
-    if user_agent:
-        logger.info("Using user-agent: %s.", user_agent)
-        suricata.update.net.set_custom_user_agent(user_agent)
-
     if args.subcommand:
         if hasattr(args, "func"):
             return args.func()

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -53,9 +53,13 @@ def set_user_agent_suricata_version(version):
 
 def build_user_agent():
     params = []
-
-    if custom_user_agent is not None:
-        return custom_user_agent
+    has_custom_user_agent = config.has("user-agent")
+    if has_custom_user_agent:
+        user_agent = config.get("user-agent")
+        if user_agent is None or len(user_agent.strip()) == 0:
+            logger.debug("Suppressing HTTP User-Agent header")
+            return None
+        return user_agent
 
     uname_system = platform.uname()[0]
 

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -60,7 +60,6 @@ def build_user_agent():
             logger.debug("Suppressing HTTP User-Agent header")
             return None
         return user_agent
-
     uname_system = platform.uname()[0]
 
     params.append("OS: %s" % (uname_system))
@@ -93,7 +92,6 @@ def get(url, fileobj, progress_hook=None):
     """
 
     user_agent = build_user_agent()
-    logger.debug("Setting HTTP user-agent to %s", user_agent)
 
     try:
         # Wrap in a try as Python versions prior to 2.7.9 don't have
@@ -107,10 +105,12 @@ def get(url, fileobj, progress_hook=None):
     except:
         opener = build_opener()
 
-    opener.addheaders = [
-        ("User-Agent", build_user_agent()),
-    ]
-
+    if user_agent:
+        logger.debug("Setting HTTP User-Agent to %s", user_agent)
+        opener.addheaders = [("User-Agent", user_agent),]
+    else:
+        opener.addheaders = [(header, value) for header,
+                             value in opener.addheaders if header.lower() != "user-agent"]
     remote = opener.open(url)
     info = remote.info()
     try:


### PR DESCRIPTION
This patchset contains two commits doing the following changes:

1. The default configuration file must be checked for the availability of
`user-agent` option even if it is None.

2. `suricata-update` sends a User Agent as a part of the request header to
get some basic information about the user system like the suricata-update
version, python version, etc. However, some users do not like this
behavior and are facililated with a `--user-agent` option whereby they
can modify the `User-Agent` header to a custom string. Although, in some
cases, it has been observed that the `User-Agent` header can be set to
nothing. In some other cases, users wish to set it to an empty string. Remove the header if it is set to a string that evaluates to nothing.

This is a rework of #55 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2665