### PR TITLE
new arguament for output rule-filename

### DIFF
--- a/doc/update.rst
+++ b/doc/update.rst
@@ -24,6 +24,12 @@ Options
 
    Default: */var/lib/suricata/rules*
 
+.. option:: -r, --output-rule-filename
+
+   Name of the output rules file.
+
+   Default: *suricata.rules*
+
 .. option:: --force
 
    Force remote rule files to be downloaded if they otherwise wouldn't

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -999,6 +999,7 @@ def copytree_ignore_backup(src, names):
 
 def _main():
     global args
+    global DEFAULT_OUTPUT_RULE_FILENAME
 
     default_update_yaml = config.DEFAULT_UPDATE_YAML_PATH
 
@@ -1027,6 +1028,9 @@ def _main():
     global_parser.add_argument(
         "--user-agent", metavar="<user-agent>",
         help="Set custom user-agent string")
+    global_parser.add_argument(
+        "-r", "--output-rule-filename", metavar="<filename>",
+        help="Filename of output rules file (default: suricata.rules)")
     global_parser.add_argument(
         "--no-check-certificate", action="store_true", default=None,
         help="Disable server SSL/TLS certificate verification")
@@ -1263,6 +1267,12 @@ def _main():
     if drop_conf_filename and os.path.exists(drop_conf_filename):
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
+
+    # Load user provided output rules filename
+    rule_filename = config.get("output-rule-filename")
+    if rule_filename:
+        logger.info("Setting output rule filename to %s", rule_filename)
+        DEFAULT_OUTPUT_RULE_FILENAME = rule_filename
 
     # Load the Suricata configuration if we can.
     suriconf = None


### PR DESCRIPTION
This feature resolves redmine issue 2659.

suricata-update currently writes the output of modified rules to a predefined output filename (suricata.rules). There currently isn't a mechanism to allow an end-user to define the name of this output file, leaving the end-user having to rename the output file after running through the rules filters, such as enable, disable, or modify.

This change features the addition of new flags [ '-r' | '--output-rule-filename' ] and permits the end-user the ability to set the output-rules filename to whatever the user wishes.

When using a custom rules file that we would want to run through suricata-update, the output of that is stored in suricata.rules, instead of maintaining the same rules filename that we fed into suricata-update.

$ suricata-update --local ~/suricata_test/jsamaroo-custom.rules --disable-conf ~/suricata_test/disable -o ~/suricata_test/ -r jsamaroo-custom.rules
7/11/2018 -- 03:46:44 - <Warning> -- No suricata application binary found on path.
7/11/2018 -- 03:46:44 - <Info> -- Using default Suricata version of 4.0.0
7/11/2018 -- 03:46:44 - <Info> -- Loading /home/jsamaroo/suricata_test/disable.
7/11/2018 -- 03:46:44 - <Info> -- Setting output rule filename to jsamaroo-custom.rules
7/11/2018 -- 03:46:44 - <Warning> -- Cache directory does not exist and could not be created. /var/tmp will be used instead.
7/11/2018 -- 03:46:44 - <Info> -- No sources configured, will use Emerging Threats Open
7/11/2018 -- 03:46:44 - <Info> -- Checking https://rules.emergingthreats.net/open/suricata-4.0.0/emerging.rules.tar.gz.md5.
7/11/2018 -- 03:46:44 - <Info> -- Remote checksum has not changed. Not fetching.
7/11/2018 -- 03:46:44 - <Info> -- Loading local file /home/jsamaroo/suricata_test/jsamaroo-custom.rules
7/11/2018 -- 03:46:44 - <Warning> -- No distribution rule directory found.
7/11/2018 -- 03:46:44 - <Info> -- Ignoring file rules/emerging-deleted.rules
7/11/2018 -- 03:46:52 - <Info> -- Loaded 47514 rules.
7/11/2018 -- 03:46:52 - <Info> -- Disabled 1 rules.
7/11/2018 -- 03:46:52 - <Info> -- Enabled 0 rules.
7/11/2018 -- 03:46:52 - <Info> -- Modified 0 rules.
7/11/2018 -- 03:46:52 - <Info> -- Dropped 0 rules.
7/11/2018 -- 03:46:52 - <Info> -- Enabled 0 rules for flowbit dependencies.
7/11/2018 -- 03:46:52 - <Info> -- Backing up current rules.
7/11/2018 -- 03:46:57 - <Info> -- Writing rules to /home/jsamaroo/suricata_test/jsamaroo-custom.rules: total: 23757; enabled: 18856; added: 0; removed 0; modified: 1
7/11/2018 -- 03:46:58 - <Info> -- No suricata application binary found, skipping test.
7/11/2018 -- 03:46:58 - <Info> -- Done.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

  I have read the contributing guide lines at
https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
  I have signed the Open Information Security Foundation
contribution agreement at
https://suricata-ids.org/about/contribution-agreement/
  I have updated the user guide (in doc/userguide/) to reflect the
changes made (if applicable)
Link
to
[redmine](https://redmine.openinfosecfoundation.org) ticket: [2659](https://redmine.openinfosecfoundation.org/issues/2659)

This is a rework of #61 

Description of changes:

- Removed additional space from docs/updates.rst
- Resolved breakage of global variable reference within function due to assignment of similar variable within function.