### PR TITLE
Add the required data for sample confs to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "suricata.update.compat.argparse",
         "suricata.update.data",
     ],
+    package_data={"suricata.update.configs": ["*.conf", "*.yaml", "*.in"]},
     url="https://github.com/OISF/suricata-update",
     license="GPLv2",
     classifiers=[


### PR DESCRIPTION
setup.py missed the required configuration files for running the
`dump-sample-configs` option. Add all the files under
suricata/update/configs.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2683