### PR TITLE
Fix missing null check

### DIFF
--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -310,7 +310,7 @@ def parse(buf, group=None):
         elif name == "reference":
             rule.references.append(val)
         elif name == "msg":
-            if val.startswith('"') and val.endswith('"'):
+            if val and val.startswith('"') and val.endswith('"'):
                 val = val[1:-1]
             rule[name] = val
         else:


### PR DESCRIPTION
Coverity discovered a missing null check for the variable `val`. Fix
 that by adding the appropriate checks for it.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2676