### PR TITLE
do not fail on repeated enabling/disabling of sources

### DIFF
--- a/suricata/update/commands/disablesource.py
+++ b/suricata/update/commands/disablesource.py
@@ -34,7 +34,7 @@ def disable_source():
     if not os.path.exists(filename):
         logger.debug("Filename %s does not exist.", filename)
         logger.warning("Source %s is not enabled.", name)
-        return 1
+        return 0
     logger.debug("Renaming %s to %s.disabled.", filename, filename)
     os.rename(filename, "%s.disabled" % (filename))
     logger.info("Source %s has been disabled", name)

--- a/suricata/update/commands/enablesource.py
+++ b/suricata/update/commands/enablesource.py
@@ -44,8 +44,8 @@ def enable_source():
     # Check if source is already enabled.
     enabled_source_filename = sources.get_enabled_source_filename(name)
     if os.path.exists(enabled_source_filename):
-        logger.error("The source %s is already enabled.", name)
-        return 1
+        logger.warning("The source %s is already enabled, keeping it enabled.", name)
+        return 0
 
     # First check if this source was previous disabled and then just
     # re-enable it.


### PR DESCRIPTION
At the moment, trying to enable a source that is already enabled will result in suricata-update failing with a return code of 1 and the error message:

```
2018-12-04 17:15:14,285 - <ERROR> - The source oisf/trafficid is already enabled.
```

This is problematic, for example, when using Ansible to set up and maintain an environment where configuration of sources is necessary. This PR introduces code that making this a warning only and not returning a nonzero return code.


- [X] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/

See ticket [2728](https://redmine.openinfosecfoundation.org/issues/2728).

Describe changes:
- Adapt messages for repeated calls of `suricata-update **enable-source`/`suricata-update disable-source` make them a warning, adapt wording.
- Ensure non-error return code when a source is already enabled/disabled.
