### PR TITLE
version: hide git revision if unknown - v1

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -67,7 +67,7 @@ from suricata.update.version import version
 try:
     from suricata.update.revision import revision
 except:
-    revision = "unknown"
+    revision = None
 
 # Initialize logging, use colour if on a tty.
 if len(logging.root.handlers) == 0 and os.isatty(sys.stderr.fileno()):
@@ -1052,7 +1052,11 @@ def _main():
     global_args, rem = global_parser.parse_known_args()
 
     if global_args.version:
-        print("suricata-update version %s (rev: %s)" % (version, revision))
+        if revision != None:
+            revision_string = " (rev: %s)" % (revision)
+        else:
+            revision_string = ""
+        print("suricata-update version %s%s" % (version, revision_string))
         return 0
 
     if not rem or rem[0].startswith("-"):


### PR DESCRIPTION
This happens when suricata-update is installed bundled with Suricata.  This is more a relic from the earlier days of Suricata-Update when more users were likely to install it directly from git anyways.
