### PR TITLE
Add the facility to mention headers while adding source

### DIFF
--- a/suricata/update/commands/addsource.py
+++ b/suricata/update/commands/addsource.py
@@ -32,10 +32,12 @@ def register(parser):
     parser.add_argument("name", metavar="<name>", nargs="?",
                         help="Name of source")
     parser.add_argument("url", metavar="<url>", nargs="?", help="Source URL")
+    parser.add_argument("--header", metavar="<header>", help="HTTP Header")
     parser.set_defaults(func=add_source)
 
 def add_source():
     args = config.args()
+    header = None
 
     if args.name:
         name = args.name
@@ -57,5 +59,8 @@ def add_source():
             if url:
                 break
 
-    source_config = sources.SourceConfiguration(name, url=url)
+    if args.header:
+        header = args.header
+
+    source_config = sources.SourceConfiguration(name, header=header, url=url)
     sources.save_source_config(source_config)

--- a/suricata/update/commands/addsource.py
+++ b/suricata/update/commands/addsource.py
@@ -32,12 +32,12 @@ def register(parser):
     parser.add_argument("name", metavar="<name>", nargs="?",
                         help="Name of source")
     parser.add_argument("url", metavar="<url>", nargs="?", help="Source URL")
-    parser.add_argument("--header", metavar="<header>", help="HTTP Header")
+    parser.add_argument("--http-header", metavar="<http-header>",
+                        help="Additional HTTP header to add to requests")
     parser.set_defaults(func=add_source)
 
 def add_source():
     args = config.args()
-    header = None
 
     if args.name:
         name = args.name
@@ -59,8 +59,7 @@ def add_source():
             if url:
                 break
 
-    if args.header:
-        header = args.header
+    header = args.header if args.header else None
 
     source_config = sources.SourceConfiguration(name, header=header, url=url)
     sources.save_source_config(source_config)

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -351,6 +351,8 @@ class Fetch:
             "%s-%s" % (url_hash, self.url_basename(url)))
 
     def fetch(self, url):
+        net_arg = url
+        url = url[0] if isinstance(url, tuple) else url
         tmp_filename = self.get_tmp_filename(url)
         if not config.args().force and os.path.exists(tmp_filename):
             if not config.args().now and \
@@ -368,7 +370,7 @@ class Fetch:
         try:
             tmp_fileobj = tempfile.NamedTemporaryFile()
             suricata.update.net.get(
-                url,
+                net_arg,
                 tmp_fileobj,
                 progress_hook=self.progress_hook)
             shutil.copyfile(tmp_fileobj.name, tmp_filename)
@@ -395,6 +397,7 @@ class Fetch:
                 fetched = self.fetch(url)
                 files.update(fetched)
             except URLError as err:
+                url = url[0] if isinstance(url, tuple) else url
                 logger.error("Failed to fetch %s: %s", url, err)
         else:
             for url in self.args.url:
@@ -957,14 +960,15 @@ def load_sources(suricata_version):
             params.update(internal_params)
             if "url" in source:
                 # No need to go off to the index.
-                url = source["url"] % params
+                url = (source["url"] % params, source.get("http-header"))
+                logger.debug("Resolved source %s to URL %s.", name, url[0])
             else:
                 if not index:
                     raise exceptions.ApplicationError(
                         "Source index is required for source %s; "
                         "run suricata-update update-sources" % (source["source"]))
                 url = index.resolve_url(name, params)
-            logger.debug("Resolved source %s to URL %s.", name, url)
+                logger.debug("Resolved source %s to URL %s.", name, url)
             urls.append(url)
 
     if config.get("sources"):

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -20,6 +20,7 @@
 import platform
 import logging
 import ssl
+import re
 
 try:
     # Python 3.3...
@@ -76,6 +77,16 @@ def build_user_agent():
     return "Suricata-Update/%s (%s)" % (
         version, "; ".join(params))
 
+
+def is_header_clean(header):
+    if len(header) != 2:
+        return False
+    name, val = header[0].strip(), header[1].strip()
+    if re.match( r"^[\w-]+$", name) and re.match(r"^[\w-]+$", val):
+        return True
+    return False
+
+
 def get(url, fileobj, progress_hook=None):
     """ Perform a GET request against a URL writing the contents into
     the provideded file like object.
@@ -107,29 +118,43 @@ def get(url, fileobj, progress_hook=None):
 
     if user_agent:
         logger.debug("Setting HTTP User-Agent to %s", user_agent)
-        opener.addheaders = [("User-Agent", user_agent),]
+        http_headers = [("User-Agent", user_agent)]
     else:
-        opener.addheaders = [(header, value) for header,
-                             value in opener.addheaders if header.lower() != "user-agent"]
-    remote = opener.open(url)
-    info = remote.info()
+        http_headers = [(header, value) for header,
+                        value in opener.addheaders if header.lower() != "user-agent"]
+    if isinstance(url, tuple):
+        header = url[1].split(":") if url[1] is not None else None
+        if header and is_header_clean(header=header):
+            name, val = header[0].strip(), header[1].strip()
+            logger.debug("Setting HTTP header %s to %s", name, val)
+            http_headers.append((name, val))
+        elif header:
+            logger.error("Header not set as it does not meet the criteria")
+        url = url[0]
+    opener.addheaders = http_headers
+
     try:
-        content_length = int(info["content-length"])
-    except:
-        content_length = 0
-    bytes_read = 0
-    while True:
-        buf = remote.read(GET_BLOCK_SIZE)
-        if not buf:
-            # EOF
-            break
-        bytes_read += len(buf)
-        fileobj.write(buf)
-        if progress_hook:
-            progress_hook(content_length, bytes_read)
-    remote.close()
-    fileobj.flush()
-    return bytes_read, info
+        remote = opener.open(url)
+    except ValueError as ve:
+        logger.error(ve)
+    else:
+        info = remote.info()
+        content_length = info.get("content-length")
+        content_length = int(content_length) if content_length else 0
+        bytes_read = 0
+        while True:
+            buf = remote.read(GET_BLOCK_SIZE)
+            if not buf:
+                # EOF
+                break
+            bytes_read += len(buf)
+            fileobj.write(buf)
+            if progress_hook:
+                progress_hook(content_length, bytes_read)
+        remote.close()
+        fileobj.flush()
+        return bytes_read, info
+
 
 if __name__ == "__main__":
 

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -77,10 +77,11 @@ def save_source_config(source_config):
 
 class SourceConfiguration:
 
-    def __init__(self, name, url=None, params={}):
+    def __init__(self, name, header, url=None, params={}):
         self.name = name
         self.url = url
         self.params = params
+        self.header = header
 
     def dict(self):
         d = {
@@ -90,6 +91,8 @@ class SourceConfiguration:
             d["url"] = self.url
         if self.params:
             d["params"] = self.params
+        if self.header:
+            d["header"] = self.header
         return d
 
 class Index:


### PR DESCRIPTION
Add header option to add source command

Facilitates addition of a header per source while adding the source.
Usage:

$ ./bin/suricata-update add-source --header "Auth: Basic"
Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/2577

This is a rework of #72 
Changes since 72:
- Replaced `header` with `http-header`
- Fix logging errors with tuples
- Fix HTTP headers being overwritten