### PR TITLE
new argument for output rule-filename

### DIFF
--- a/doc/update.rst
+++ b/doc/update.rst
@@ -24,6 +24,12 @@ Options
 
    Default: */var/lib/suricata/rules*
 
+.. option:: --output-rule-filename
+
+   Name of the output rules file.
+
+   Default: *suricata.rules*
+
 .. option:: --force
 
    Force remote rule files to be downloaded if they otherwise wouldn't

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -999,6 +999,7 @@ def copytree_ignore_backup(src, names):
 
 def _main():
     global args
+    global DEFAULT_OUTPUT_RULE_FILENAME
 
     default_update_yaml = config.DEFAULT_UPDATE_YAML_PATH
 
@@ -1027,6 +1028,9 @@ def _main():
     global_parser.add_argument(
         "--user-agent", metavar="<user-agent>",
         help="Set custom user-agent string")
+    global_parser.add_argument(
+        "--output-rule-filename", metavar="<filename>",
+        help="Filename of output rules file (default: suricata.rules)")
     global_parser.add_argument(
         "--no-check-certificate", action="store_true", default=None,
         help="Disable server SSL/TLS certificate verification")
@@ -1263,6 +1267,15 @@ def _main():
     if drop_conf_filename and os.path.exists(drop_conf_filename):
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
+
+    # Load user provided output rules filename
+    rule_filename = config.get("output-rule-filename")
+    if rule_filename:
+        if args.no_merge:
+            logger.error("Cannot use flag --output-rule-filename when using --no-merge since it will not have an affect, exiting.")
+            sys.exit(1)
+        logger.info("Setting output rule filename to %s", rule_filename)
+        DEFAULT_OUTPUT_RULE_FILENAME = rule_filename
 
     # Load the Suricata configuration if we can.
     suriconf = None


### PR DESCRIPTION
This feature resolves redmine issue 2659.

suricata-update currently writes the output of modified rules to a predefined output filename (suricata.rules). There currently isn't a mechanism to allow an end-user to define the name of this output file, leaving the end-user having to rename the output file after running through the rules filters, such as enable, disable, or modify.

This change features the addition of new flag '--output-rule-filename' which permits the end-user to set the output-rules filename to whatever the user wishes.
However if '--no-merge' flag is used with the '--output-rule-filename' flag, then the program will exit with an error notifying the enduser of the reason.

When using a custom rules file that we would want to run through suricata-update, the output of that is stored in suricata.rules (which is the default filename), instead of maintaining the same rules filename that we fed into the suricata-update program.

$ suricata-update --local ~/suricata_test/jsamaroo-custom.rules --disable-conf ~/suricata_test/disable -o ~/suricata_test/ --output-rule-filename jsamaroo-custom.rules
15/12/2018 -- 13:15:31 - <Warning> -- No suricata application binary found on path.
15/12/2018 -- 13:15:31 - <Info> -- Using default Suricata version of 4.0.0
15/12/2018 -- 13:15:31 - <Info> -- Loading /Users/jsamaroo/suricata_test/disable.
15/12/2018 -- 13:15:31 - <Info> -- Setting output rule filename to jsamaroo-custom.rules
15/12/2018 -- 13:15:31 - <Warning> -- Cache directory does not exist and could not be created. /var/tmp will be used instead.
15/12/2018 -- 13:15:31 - <Info> -- No sources configured, will use Emerging Threats Open
15/12/2018 -- 13:15:31 - <Info> -- Checking https://rules.emergingthreats.net/open/suricata-4.0.0/emerging.rules.tar.gz.md5.
15/12/2018 -- 13:15:31 - <Info> -- Fetching https://rules.emergingthreats.net/open/suricata-4.0.0/emerging.rules.tar.gz.
 100% - 2302876/2302876
15/12/2018 -- 13:15:32 - <Info> -- Done.
15/12/2018 -- 13:15:32 - <Info> -- Loading local file /Users/jsamaroo/suricata_test/jsamaroo-custom.rules
15/12/2018 -- 13:15:32 - <Warning> -- No distribution rule directory found.
15/12/2018 -- 13:15:32 - <Info> -- Ignoring file rules/emerging-deleted.rules
15/12/2018 -- 13:15:40 - <Info> -- Loaded 47643 rules.
15/12/2018 -- 13:15:40 - <Info> -- Disabled 0 rules.
15/12/2018 -- 13:15:40 - <Info> -- Enabled 0 rules.
15/12/2018 -- 13:15:40 - <Info> -- Modified 0 rules.
15/12/2018 -- 13:15:40 - <Info> -- Dropped 0 rules.
15/12/2018 -- 13:15:40 - <Info> -- Enabled 0 rules for flowbit dependencies.
15/12/2018 -- 13:15:40 - <Info> -- Backing up current rules.
15/12/2018 -- 13:15:45 - <Info> -- Writing rules to /Users/jsamaroo/suricata_test/jsamaroo-custom.rules: total: 23912; enabled: 19010; added: 155; removed 0; modified: 1174
15/12/2018 -- 13:15:45 - <Info> -- No suricata application binary found, skipping test.
15/12/2018 -- 13:15:45 - <Info> -- Done.

Using no-merge and output-rule-filename together:
$ suricata-update --no-merge --local ~/suricata_test/jsamaroo-custom.rules --disable-conf ~/suricata_test/disable -o ~/suricata_test/ --output-rule-filename jsamaroo-custom.rules
15/12/2018 -- 13:16:34 - <Warning> -- No suricata application binary found on path.
15/12/2018 -- 13:16:34 - <Info> -- Using default Suricata version of 4.0.0
15/12/2018 -- 13:16:34 - <Info> -- Loading /Users/jsamaroo/suricata_test/disable.
15/12/2018 -- 13:16:34 - <Error> -- Cannot use flag --output-rule-filename when using --no-merge since it will not have an affect, exiting.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
[2659](https://redmine.openinfosecfoundation.org/issues/2659)

This is a rework of #62  

Description of changes:

- Removed ‘-r’ flag as short argument 
- Printing an error and exiting the program when no-merge and output-rule-filename are used together.