### PR TITLE
Fix the broken sys import of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os.path
 import subprocess
 import distutils
 from distutils.core import setup
+from distutils.core import sys
 
 from suricata.update.version import version
 
@@ -45,7 +46,7 @@ args = {
     ],
 }
 
-if any("pip" in arg for arg in distutils.sys.argv):
+if any("pip" in arg for arg in sys.argv):
     args["install_requires"] = ["pyyaml", ]
 
 setup(**args)


### PR DESCRIPTION
Newer distutils versions allow to list and work with `sys` as it is
imported in the `__init__.py` however, the older versions of disutils
does not contain anything other than the version and revision strings.
The current installation procedure relied on the former method which is
only adapted in the new versions so make it compatible to the older
versions by importing `sys` from `distutils.core`.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2747