### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.0.2 - 2018-12-18
+- Fix installs on older versions of Python 2.7.
+  https://redmine.openinfosecfoundation.org/issues/2747
 ## 1.0.1 - 2018-12-16
 - Add --free argument to list-sources command to show only those
   that are freely

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os.path
 import subprocess
 import distutils
 from distutils.core import setup
+from distutils.core import sys
 
 from suricata.update.version import version
 
@@ -45,7 +46,7 @@ args = {
     ],
 }
 
-if any("pip" in arg for arg in distutils.sys.argv):
+if any("pip" in arg for arg in sys.argv):
     args["install_requires"] = ["pyyaml", ]
 
 setup(**args)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import os.path
 import subprocess
 import distutils
@@ -6,6 +7,13 @@ from distutils.core import sys
 
 from suricata.update.version import version
 
+
+version_major = sys.version_info[0]
+version_minor = sys.version_info[1]
+
+if version_major < 3 and version_minor < 7:
+    print("Suricata-Update requires Python 2.7 or newer.")
+    sys.exit(0)
 
 def write_git_revision():
     if not os.path.exists(".git"):

--- a/suricata/update/version.py
+++ b/suricata/update/version.py
@@ -4,4 +4,4 @@
 # Alpha: 1.0.0a1
 # Development: 1.0.0.dev0
 # Release candidate: 1.0.0rc1
-version = "1.0.1"
+version = "1.0.2"


### PR DESCRIPTION
Release 1.0.2.
- Fix broken installation script on CentOS 6.
- Check for a minimum of Python 2.7 before installing.
