### PR TITLE
Make header an optional argument

### DIFF
--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -77,7 +77,7 @@ def save_source_config(source_config):
 
 class SourceConfiguration:
 
-    def __init__(self, name, header, url=None, params={}):
+    def __init__(self, name, header=None, url=None, params={}):
         self.name = name
         self.url = url
         self.params = params


### PR DESCRIPTION
header was being used as a required argument in SourceConfiguration
class. Since SourceConfiguration class has been used multiple times
across commands, not all the commands require header argument and thus
it breaks. Fix it by making header an optional argument.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2753