### PR TITLE
Rules log file/v2

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -32,6 +32,8 @@ import shutil
 import glob
 import io
 import tempfile
+import json
+from datetime import datetime as dt
 
 try:
     # Python 3.
@@ -68,7 +70,6 @@ try:
     from suricata.update.revision import revision
 except:
     revision = None
-
 # Initialize logging, use colour if on a tty.
 if len(logging.root.handlers) == 0 and os.isatty(sys.stderr.fileno()):
     logger = logging.getLogger()
@@ -572,6 +573,39 @@ def load_dist_rules(files):
                 logger.error("Failed to open %s: %s" % (path, err))
                 sys.exit(1)
 
+
+def add_to_box(string):
+    max_len = len(string)
+    pretty_str = "*" * max_len * 3
+    pretty_space = " " * (max_len - 4)
+    boxed_string = "\n{}\n*{}{} Rules{}*\n{}\n\n".format(pretty_str,
+            pretty_space,
+            string.title(),
+            pretty_space,
+            pretty_str)
+    return boxed_string
+
+
+def log_report(report):
+    fpath = config.get("report")
+    if not fpath:
+        return
+    with open(fpath, "w") as f:
+        f.write("Generated on {}\n\n".format(
+            dt.now().strftime("%A, %d %b %Y, %H:%M:%S %Z")))
+        for key in report.keys():
+            if not len(report[key]) > 0:
+                continue
+            f.write(add_to_box(key))
+            for rule in report[key]:
+                rule_dict = {
+                        "sid": rule["sid"],
+                        "rev": rule["rev"],
+                        "msg": rule["msg"],
+                        }
+                f.write("{}\n".format(json.dumps(rule_dict)))
+
+
 def build_report(prev_rulemap, rulemap):
     """Build a report of changes between 2 rulemaps.
 
@@ -608,19 +642,20 @@ def write_merged(filename, rulemap):
             prev_rulemap = build_rule_map(
                 suricata.update.rule.parse_file(filename))
         report = build_report(prev_rulemap, rulemap)
-        enabled = len([rule for rule in rulemap.values() if rule.enabled])
+        report["enabled"] = [rule for rule in rulemap.values() if rule.enabled]
         logger.info("Writing rules to %s: total: %d; enabled: %d; "
                     "added: %d; removed %d; modified: %d" % (
                         filename,
                         len(rulemap),
-                        enabled,
+                        len(report["enabled"]),
                         len(report["added"]),
                         len(report["removed"]),
                         len(report["modified"])))
-    
+
     with io.open(filename, encoding="utf-8", mode="w") as fileobj:
         for rule in rulemap:
             print(rulemap[rule].format(), file=fileobj)
+    log_report(report=report)
 
 def write_to_directory(directory, files, rulemap):
     if not args.quiet:
@@ -632,12 +667,12 @@ def write_to_directory(directory, files, rulemap):
                 previous_rulemap.update(build_rule_map(
                     suricata.update.rule.parse_file(outpath)))
         report = build_report(previous_rulemap, rulemap)
-        enabled = len([rule for rule in rulemap.values() if rule.enabled])
+        report["enabled"] = [rule for rule in rulemap.values() if rule.enabled]
         logger.info("Writing rule files to directory %s: total: %d; "
                     "enabled: %d; added: %d; removed %d; modified: %d" % (
                         directory,
                         len(rulemap),
-                        enabled,
+                        len(report["enabled"]),
                         len(report["added"]),
                         len(report["removed"]),
                         len(report["modified"])))
@@ -658,6 +693,7 @@ def write_to_directory(directory, files, rulemap):
                     content.append(rulemap[rule.id].format())
             io.open(outpath, encoding="utf-8", mode="w").write(
                 u"\n".join(content))
+    log_report(report=report)
 
 def write_yaml_fragment(filename, files):
     logger.info(
@@ -1095,7 +1131,6 @@ def _main():
                                help="Generate a sid-msg.map file")
     update_parser.add_argument("--sid-msg-map-2", metavar="<filename>",
                                help="Generate a v2 sid-msg.map file")
-    
     update_parser.add_argument("--disable-conf", metavar="<filename>",
                                help="Filename of rule disable filters")
     update_parser.add_argument("--enable-conf", metavar="<filename>",
@@ -1104,19 +1139,18 @@ def _main():
                                help="Filename of rule modification filters")
     update_parser.add_argument("--drop-conf", metavar="<filename>",
                                help="Filename of drop rules filters")
-    
+    update_parser.add_argument("--report", metavar="<filename>",
+                               help="Filename of the report for rules")
     update_parser.add_argument("--ignore", metavar="<pattern>", action="append",
                                default=[],
                                help="Filenames to ignore (can be specified multiple times; default: *deleted.rules)")
     update_parser.add_argument("--no-ignore", action="store_true",
                                default=False,
                                help="Disables the ignore option.")
-    
     update_parser.add_argument("--threshold-in", metavar="<filename>",
                                help="Filename of rule thresholding configuration")
     update_parser.add_argument("--threshold-out", metavar="<filename>",
                                help="Output of processed threshold configuration")
-    
     update_parser.add_argument("--dump-sample-configs", action="store_true",
                                default=False,
                                help="Dump sample config files to current directory")
@@ -1130,7 +1164,6 @@ def _main():
                                help="Command to test Suricata configuration")
     update_parser.add_argument("--no-test", action="store_true", default=False,
                                help="Disable testing rules with Suricata")
-    
     update_parser.add_argument("--no-merge", action="store_true", default=False,
                                help="Do not merge the rules into a single file")
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -17,23 +17,31 @@
 
 from __future__ import print_function
 
-import sys
-import re
-import os.path
-import logging
 import argparse
-import shlex
-import time
-import hashlib
 import fnmatch
-import subprocess
-import types
-import shutil
 import glob
+import hashlib
 import io
-import tempfile
 import json
+import logging
+import os.path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import types
 from datetime import datetime as dt
+
+import suricata.update.engine
+import suricata.update.loghandler
+import suricata.update.net
+import suricata.update.rule
+from suricata.update import (commands, config, configs, exceptions, extract,
+                             notes, sources, util)
+from suricata.update.version import version
 
 try:
     # Python 3.
@@ -52,20 +60,7 @@ if sys.argv[0] == __file__:
     sys.path.insert(
         0, os.path.abspath(os.path.join(__file__, "..", "..", "..")))
 
-import suricata.update.rule
-import suricata.update.engine
-import suricata.update.net
-import suricata.update.loghandler
-from suricata.update import config
-from suricata.update import configs
-from suricata.update import extract
-from suricata.update import util
-from suricata.update import sources
-from suricata.update import commands
-from suricata.update import exceptions
-from suricata.update import notes
 
-from suricata.update.version import version
 try:
     from suricata.update.revision import revision
 except:


### PR DESCRIPTION
Add a `--report <filename>` option so that the end user is able to log a
report about the rules enabled, disabled, modified and dropped.

Usage
```
└─ $ ▶ ./bin/suricata-update --report /tmp/rules.log
```

Sample Report

```
Generated on Wednesday, 09 Jan 2019, 23:30:43

***************
* Added Rules *
***************

{"sid": 2523406, "rev": 3568, "msg": "ET TOR Known Tor Relay/Router (Not Exit) Node Traffic group 704"}
{"sid": 2523408, "rev": 3568, "msg": "ET TOR Known Tor Relay/Router (Not Exit) Node Traffic group 705"}
{"sid": 2026766, "rev": 1, "msg": "ET TROJAN Operation Cobra Venom WSF Stage 2 - CnC Checkin"}

*********************
*   Removed Rules   *
*********************

{"sid": 2520166, "rev": 3567, "msg": "ET TOR Known Tor Exit Node Traffic group 84"}
{"sid": 2520168, "rev": 3567, "msg": "ET TOR Known Tor Exit Node Traffic group 85"}

************************
*    Modified Rules    *
************************

{"sid": 2012452, "rev": 2, "msg": "ET MOBILE_MALWARE Android Trojan MSO.PJApps checkin 2"}
{"sid": 2012453, "rev": 3, "msg": "ET MOBILE_MALWARE Android Trojan DroidDream Command and Control Communication"}
{"sid": 2012454, "rev": 2, "msg": "ET MOBILE_MALWARE Android Trojan Fake10086 checkin 1"}

```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2256

NOTE: Kindly ignore the formatting here, please check on command line.

Changes since v1:
- Logged only the rules modified by rule source
- Added only `msg`, `rev`, `sid` to the report
- Made report look better
- Sorted the imports

This is a rework of #82 