### PR TITLE
Rules log file/v4

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -17,23 +17,31 @@
 
 from __future__ import print_function
 
-import sys
-import re
-import os.path
-import logging
 import argparse
-import shlex
-import time
-import hashlib
 import fnmatch
-import subprocess
-import types
-import shutil
 import glob
+import hashlib
 import io
-import tempfile
 import json
+import logging
+import os.path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import types
 from datetime import datetime as dt
+
+import suricata.update.engine
+import suricata.update.loghandler
+import suricata.update.net
+import suricata.update.rule
+from suricata.update import (commands, config, configs, exceptions, extract,
+                             notes, sources, util)
+from suricata.update.version import version
 
 try:
     # Python 3.
@@ -52,20 +60,7 @@ if sys.argv[0] == __file__:
     sys.path.insert(
         0, os.path.abspath(os.path.join(__file__, "..", "..", "..")))
 
-import suricata.update.rule
-import suricata.update.engine
-import suricata.update.net
-import suricata.update.loghandler
-from suricata.update import config
-from suricata.update import configs
-from suricata.update import extract
-from suricata.update import util
-from suricata.update import sources
-from suricata.update import commands
-from suricata.update import exceptions
-from suricata.update import notes
 
-from suricata.update.version import version
 try:
     from suricata.update.revision import revision
 except:


### PR DESCRIPTION
Add a `--report <filename>` option so that the end user is able to log a
report about the rules enabled, disabled, modified and dropped.

Usage
```
└─ $ ▶ ./bin/suricata-update --report /tmp/rules.log
```

Sample Report

```
Generated on Wednesday, 09 Jan 2019, 23:30:43

Added Rules
===========
 # [1:2002101] ET GAMES Battle.net Starcraft login
(emerging-games.rules)
 # [1:2002102] ET GAMES Battle.net Brood War login
(emerging-games.rules)
 # [1:2002103] ET GAMES Battle.net Diablo login
(emerging-games.rules)
 # [1:2002104] ET GAMES Battle.net Diablo 2 login
(emerging-games.rules)
```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2256

Changes since v3:
- Fix the commit message

This is a rework of #87 