### PR TITLE
Avoid failure in case of obsoletion of attribute

### DIFF
--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -67,7 +67,7 @@ def build_user_agent():
     params.append("CPU: %s" % (platform.machine()))
     params.append("Python: %s" % (platform.python_version()))
 
-    if uname_system == "Linux":
+    if uname_system == "Linux" and hasattr(platform, "linux_distribution"):
         distribution = platform.linux_distribution()
         params.append("Dist: %s/%s" % (
             str(distribution[0]), str(distribution[1])))


### PR DESCRIPTION
`platform` is currently (Py3.7) shipped with `linux_distribution`
attribute but it has been Deprecated since Py3.5. In future when it
becomes obsolete, suricata-update will break while creating User-Agent
header. In order to avoid this, check for the attribute before adding it
to User-Agent.

This renders redmine issue #2645 invalid.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2645