### PR TITLE
Rules log file/v5

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -17,23 +17,31 @@
 
 from __future__ import print_function
 
-import sys
-import re
-import os.path
-import logging
 import argparse
-import shlex
-import time
-import hashlib
 import fnmatch
-import subprocess
-import types
-import shutil
 import glob
+import hashlib
 import io
-import tempfile
 import json
+import logging
+import os.path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import types
 from datetime import datetime as dt
+
+import suricata.update.engine
+import suricata.update.loghandler
+import suricata.update.net
+import suricata.update.rule
+from suricata.update import (commands, config, configs, exceptions, extract,
+                             notes, sources, util)
+from suricata.update.version import version
 
 try:
     # Python 3.
@@ -52,20 +60,7 @@ if sys.argv[0] == __file__:
     sys.path.insert(
         0, os.path.abspath(os.path.join(__file__, "..", "..", "..")))
 
-import suricata.update.rule
-import suricata.update.engine
-import suricata.update.net
-import suricata.update.loghandler
-from suricata.update import config
-from suricata.update import configs
-from suricata.update import extract
-from suricata.update import util
-from suricata.update import sources
-from suricata.update import commands
-from suricata.update import exceptions
-from suricata.update import notes
 
-from suricata.update.version import version
 try:
     from suricata.update.revision import revision
 except:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -32,6 +32,8 @@ import shutil
 import glob
 import io
 import tempfile
+import json
+from datetime import datetime as dt
 
 try:
     # Python 3.
@@ -68,7 +70,6 @@ try:
     from suricata.update.revision import revision
 except:
     revision = None
-
 # Initialize logging, use colour if on a tty.
 if len(logging.root.handlers) == 0 and os.isatty(sys.stderr.fileno()):
     logger = logging.getLogger()
@@ -572,6 +573,27 @@ def load_dist_rules(files):
                 logger.error("Failed to open %s: %s" % (path, err))
                 sys.exit(1)
 
+
+def log_report(report):
+    fpath = config.get("report")
+    if not fpath:
+        return
+    with open(fpath, "w") as f:
+        f.write("Generated on {}\n\n".format(
+            dt.now().strftime("%A, %d %b %Y, %H:%M:%S")))
+        for key in report.keys():
+            if not len(report[key]) > 0:
+                continue
+            f.write("\n{} Rules\n{}\n".format(key.title(), "=" * (len(key) + 6)))
+            for rule in report[key]:
+                rule_group = rule.get("group")
+                rule_fname = rule_group.split("/")[-1] if rule_group else None
+                fmt_string =  " ({})".format(
+                        rule_fname.split(".")[0] if rule_fname else None)
+                f.write("{}{}\n".format(
+                    rule.brief(), fmt_string if rule_fname else ""))
+
+
 def build_report(prev_rulemap, rulemap):
     """Build a report of changes between 2 rulemaps.
 
@@ -586,7 +608,6 @@ def build_report(prev_rulemap, rulemap):
         "removed": [],
         "modified": []
     }
-
     for key in rulemap:
         rule = rulemap[key]
         if not rule.id in prev_rulemap:
@@ -617,10 +638,11 @@ def write_merged(filename, rulemap):
                         len(report["added"]),
                         len(report["removed"]),
                         len(report["modified"])))
-    
+
     with io.open(filename, encoding="utf-8", mode="w") as fileobj:
         for rule in rulemap:
             print(rulemap[rule].format(), file=fileobj)
+    log_report(report=report)
 
 def write_to_directory(directory, files, rulemap):
     if not args.quiet:
@@ -658,6 +680,7 @@ def write_to_directory(directory, files, rulemap):
                     content.append(rulemap[rule.id].format())
             io.open(outpath, encoding="utf-8", mode="w").write(
                 u"\n".join(content))
+    log_report(report=report)
 
 def write_yaml_fragment(filename, files):
     logger.info(
@@ -1095,7 +1118,6 @@ def _main():
                                help="Generate a sid-msg.map file")
     update_parser.add_argument("--sid-msg-map-2", metavar="<filename>",
                                help="Generate a v2 sid-msg.map file")
-    
     update_parser.add_argument("--disable-conf", metavar="<filename>",
                                help="Filename of rule disable filters")
     update_parser.add_argument("--enable-conf", metavar="<filename>",
@@ -1104,19 +1126,18 @@ def _main():
                                help="Filename of rule modification filters")
     update_parser.add_argument("--drop-conf", metavar="<filename>",
                                help="Filename of drop rules filters")
-    
+    update_parser.add_argument("--report", metavar="<filename>",
+                               help="Filename of the report for rules")
     update_parser.add_argument("--ignore", metavar="<pattern>", action="append",
                                default=[],
                                help="Filenames to ignore (can be specified multiple times; default: *deleted.rules)")
     update_parser.add_argument("--no-ignore", action="store_true",
                                default=False,
                                help="Disables the ignore option.")
-    
     update_parser.add_argument("--threshold-in", metavar="<filename>",
                                help="Filename of rule thresholding configuration")
     update_parser.add_argument("--threshold-out", metavar="<filename>",
                                help="Output of processed threshold configuration")
-    
     update_parser.add_argument("--dump-sample-configs", action="store_true",
                                default=False,
                                help="Dump sample config files to current directory")
@@ -1130,7 +1151,6 @@ def _main():
                                help="Command to test Suricata configuration")
     update_parser.add_argument("--no-test", action="store_true", default=False,
                                help="Disable testing rules with Suricata")
-    
     update_parser.add_argument("--no-merge", action="store_true", default=False,
                                help="Do not merge the rules into a single file")
 


### PR DESCRIPTION
Add a `--report <filename>` option so that the end user is able to log a
report about the rules enabled, disabled, modified and dropped.

Usage
```
└─ $ ▶ ./bin/suricata-update --report /tmp/rules.log
```

Sample Report

```
Generated on Thursday, 17 Jan 2019, 02:59:37

Summary
=======
Rules disabled by disable.conf: 0
Rules enabled by enable.conf: 0
Rules modified by modify.conf: 0
Rules converted to drop: 0
Rules enabled for flowbit dependencies: 188
Rules added: 100
Rules removed: 0
Rules modified: 0

Added Rules
===========
[1:2403300] ET CINS Active Threat Intelligence Poor Reputation IP group 1 (ciarmy)
[1:2403301] ET CINS Active Threat Intelligence Poor Reputation IP group 2 (ciarmy)
[1:2403302] ET CINS Active Threat Intelligence Poor Reputation IP group 3 (ciarmy)
[1:2403303] ET CINS Active Threat Intelligence Poor Reputation IP group 4 (ciarmy)
[1:2403304] ET CINS Active Threat Intelligence Poor Reputation IP group 5 (ciarmy)
```

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2256

Changes since v4:
- Make rules compact
- Add rule summary

This is a rework of #88 