### PR TITLE
do not fail on repeated enabling/disabling of sources -- v3

### DIFF
--- a/doc/enable-source.rst
+++ b/doc/enable-source.rst
@@ -25,6 +25,10 @@ For example::
 This will prevent the prompt for the et/pro secret code using the
 value provided on the command line instead.
 
+To update parameters for enabled sources, just re-run the ``enable-source``
+command above again with changed parameters. Changed parameters will be
+updated in the stored configuration.
+
 Options
 =======
 

--- a/suricata/update/commands/disablesource.py
+++ b/suricata/update/commands/disablesource.py
@@ -34,7 +34,7 @@ def disable_source():
     if not os.path.exists(filename):
         logger.debug("Filename %s does not exist.", filename)
         logger.warning("Source %s is not enabled.", name)
-        return 1
+        return 0
     logger.debug("Renaming %s to %s.disabled.", filename, filename)
     os.rename(filename, "%s.disabled" % (filename))
     logger.info("Source %s has been disabled", name)

--- a/suricata/update/commands/enablesource.py
+++ b/suricata/update/commands/enablesource.py
@@ -40,20 +40,21 @@ def register(parser):
 
 def enable_source():
     name = config.args().name
+    updating = False
 
     # Check if source is already enabled.
     enabled_source_filename = sources.get_enabled_source_filename(name)
     if os.path.exists(enabled_source_filename):
-        logger.warning("The source %s is already enabled, keeping it enabled.", name)
-        return 0
+        logger.warning("The source %s is already enabled.", name)
+        updating = True
 
     # First check if this source was previous disabled and then just
     # re-enable it.
     disabled_source_filename = sources.get_disabled_source_filename(name)
     if os.path.exists(disabled_source_filename):
-        logger.info("Re-enabling previous disabled source for %s.", name)
+        logger.info("Re-enabling previously disabled source for %s.", name)
         os.rename(disabled_source_filename, enabled_source_filename)
-        return 0
+        updating = True
 
     if not os.path.exists(sources.get_index_filename()):
         logger.warning("Source index does not exist, will use bundled one.")
@@ -71,25 +72,35 @@ def enable_source():
         key, val = param.split("=", 1)
         opts[key] = val
 
-    source = source_index.get_sources()[name]
-
-    if "subscribe-url" in source:
-        print("The source %s requires a subscription. Subscribe here:" % (name))
-        print("  %s" % source["subscribe-url"])
-
     params = {}
-    if "parameters" in source:
-        for param in source["parameters"]:
-            if param in opts:
-                params[param] = opts[param]
-            else:
-                prompt = source["parameters"][param]["prompt"]
-                while True:
-                    r = input("%s (%s): " % (prompt, param))
-                    r = r.strip()
-                    if r:
-                        break
-                params[param] = r.strip()
+    if updating:
+        source = yaml.safe_load(open(sources.get_enabled_source_filename(name), "rb"))
+        if "params" in source:
+            params = source["params"]
+            for old_param in source["params"]:
+                if old_param in opts and source["params"][old_param] != opts[old_param]:
+                    logger.info("Updating source parameter '%s': '%s' -> '%s'." % (
+                        old_param, source["params"][old_param], opts[old_param]))
+                    params[old_param] = opts[old_param]
+    else:
+        source = source_index.get_sources()[name]
+
+        if "subscribe-url" in source:
+            print("The source %s requires a subscription. Subscribe here:" % (name))
+            print("  %s" % source["subscribe-url"])
+
+        if "parameters" in source:
+            for param in source["parameters"]:
+                if param in opts:
+                    params[param] = opts[param]
+                else:
+                    prompt = source["parameters"][param]["prompt"]
+                    while True:
+                        r = input("%s (%s): " % (prompt, param))
+                        r = r.strip()
+                        if r:
+                            break
+                    params[param] = r.strip()
     new_source = sources.SourceConfiguration(name, params=params)
 
     # If the source directory does not exist, create it. Also create

--- a/suricata/update/commands/enablesource.py
+++ b/suricata/update/commands/enablesource.py
@@ -40,13 +40,13 @@ def register(parser):
 
 def enable_source():
     name = config.args().name
-    updating = False
+    update_params = False
 
     # Check if source is already enabled.
     enabled_source_filename = sources.get_enabled_source_filename(name)
     if os.path.exists(enabled_source_filename):
         logger.warning("The source %s is already enabled.", name)
-        updating = True
+        update_params = True
 
     # First check if this source was previous disabled and then just
     # re-enable it.
@@ -54,7 +54,7 @@ def enable_source():
     if os.path.exists(disabled_source_filename):
         logger.info("Re-enabling previously disabled source for %s.", name)
         os.rename(disabled_source_filename, enabled_source_filename)
-        updating = True
+        update_params = True
 
     if not os.path.exists(sources.get_index_filename()):
         logger.warning("Source index does not exist, will use bundled one.")
@@ -73,34 +73,36 @@ def enable_source():
         opts[key] = val
 
     params = {}
-    if updating:
+    if update_params:
         source = yaml.safe_load(open(sources.get_enabled_source_filename(name), "rb"))
-        if "params" in source:
-            params = source["params"]
-            for old_param in source["params"]:
-                if old_param in opts and source["params"][old_param] != opts[old_param]:
-                    logger.info("Updating source parameter '%s': '%s' -> '%s'." % (
-                        old_param, source["params"][old_param], opts[old_param]))
-                    params[old_param] = opts[old_param]
     else:
         source = source_index.get_sources()[name]
 
-        if "subscribe-url" in source:
-            print("The source %s requires a subscription. Subscribe here:" % (name))
-            print("  %s" % source["subscribe-url"])
+    if "params" in source:
+        params = source["params"]
+        for old_param in source["params"]:
+            if old_param in opts and source["params"][old_param] != opts[old_param]:
+                logger.info("Updating source parameter '%s': '%s' -> '%s'." % (
+                    old_param, source["params"][old_param], opts[old_param]))
+                params[old_param] = opts[old_param]
 
-        if "parameters" in source:
-            for param in source["parameters"]:
-                if param in opts:
-                    params[param] = opts[param]
-                else:
-                    prompt = source["parameters"][param]["prompt"]
-                    while True:
-                        r = input("%s (%s): " % (prompt, param))
-                        r = r.strip()
-                        if r:
-                            break
-                    params[param] = r.strip()
+    if "subscribe-url" in source:
+        print("The source %s requires a subscription. Subscribe here:" % (name))
+        print("  %s" % source["subscribe-url"])
+
+    if "parameters" in source:
+        for param in source["parameters"]:
+            if param in opts:
+                params[param] = opts[param]
+            else:
+                prompt = source["parameters"][param]["prompt"]
+                while True:
+                    r = input("%s (%s): " % (prompt, param))
+                    r = r.strip()
+                    if r:
+                        break
+                params[param] = r.strip()
+
     new_source = sources.SourceConfiguration(name, params=params)
 
     # If the source directory does not exist, create it. Also create

--- a/suricata/update/commands/enablesource.py
+++ b/suricata/update/commands/enablesource.py
@@ -44,8 +44,8 @@ def enable_source():
     # Check if source is already enabled.
     enabled_source_filename = sources.get_enabled_source_filename(name)
     if os.path.exists(enabled_source_filename):
-        logger.error("The source %s is already enabled.", name)
-        return 1
+        logger.warning("The source %s is already enabled, keeping it enabled.", name)
+        return 0
 
     # First check if this source was previous disabled and then just
     # re-enable it.


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-update/pull/85

Makes sure to update parameters when re-enabling a source, printing a log message for each changed parameter.

- [X] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/) to reflect the
  changes made 

See ticket [2728](https://redmine.openinfosecfoundation.org/issues/2728).

Describe changes:
- Use descriptive variable name.
- Restructure code flow to reduce nesting.