### PR TITLE
Add timeout of 30 sec for all GET requests

### DIFF
--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -134,7 +134,7 @@ def get(url, fileobj, progress_hook=None):
     opener.addheaders = http_headers
 
     try:
-        remote = opener.open(url)
+        remote = opener.open(url, timeout=30)
     except ValueError as ve:
         logger.error(ve)
     else:


### PR DESCRIPTION
suricata-update has been reported to get hung in case the download fails
for a particular source. Add a timeout parameter to urllib to avoid that
and continue further processing after a timeout of 30 seconds.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2703