### PR TITLE
Issue 2791 - optimize memory usage - v1

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -286,14 +286,8 @@ class DropRuleFilter(object):
     def __init__(self, matcher):
         self.matcher = matcher
 
-    def is_noalert(self, rule):
-        for option in rule.options:
-            if option["name"] == "flowbits" and option["value"] == "noalert":
-                return True
-        return False
-
     def match(self, rule):
-        if self.is_noalert(rule):
+        if rule["noalert"]:
             return False
         return self.matcher.match(rule)
 

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -106,8 +106,6 @@ class Rule(dict):
         self["priority"] = 0
         self["noalert"] = False
 
-        self["options"] = []
-
         self["raw"] = None
 
     def __getattr__(self, name):
@@ -149,40 +147,6 @@ class Rule(dict):
 
     def format(self):
         return u"%s%s" % (u"" if self.enabled else u"# ", self.raw)
-
-    def rebuild_options(self):
-        """ Rebuild the rule options from the list of options."""
-        options = []
-        for option in self.options:
-            if option["value"] is None:
-                options.append(option["name"])
-            else:
-                options.append("%s:%s" % (option["name"], option["value"]))
-        return "%s;" % "; ".join(options)
-
-def remove_option(rule, name):
-    rule["options"] = [
-        option for option in rule["options"] if option["name"] != name]
-    new_rule_string = "%s%s (%s)" % (
-        "" if rule.enabled else "# ",
-        rule["header"].strip(),
-        rule.rebuild_options());
-    return parse(new_rule_string, rule["group"])
-
-def add_option(rule, name, value, index=None):
-    option = {
-        "name": name,
-        "value": value,
-    }
-    if index is None:
-        rule["options"].append(option)
-    else:
-        rule["options"].insert(index, option)
-    new_rule_string = "%s%s (%s)" % (
-        "" if rule.enabled else "# ",
-        rule["header"].strip(),
-        rule.rebuild_options())
-    return parse(new_rule_string, rule["group"])
 
 def find_opt_end(options):
     """ Find the end of an option (;) handling escapes. """
@@ -295,11 +259,6 @@ def parse(buf, group=None):
         else:
             name = option
             val = None
-
-        rule["options"].append({
-            "name": name,
-            "value": val,
-        })
 
         if name in ["gid", "sid", "rev"]:
             rule[name] = int(val)

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -75,6 +75,7 @@ class Rule(dict):
     - **references**: References as a list
     - **classtype**: The classification type
     - **priority**: The rule priority, 0 if not provided
+    - **noalert**: Is the rule a noalert rule
     - **raw**: The raw rule as read from the file or buffer
 
     :param enabled: Optional parameter to set the enabled state of the rule
@@ -103,6 +104,7 @@ class Rule(dict):
         self["references"] = []
         self["classtype"] = None
         self["priority"] = 0
+        self["noalert"] = False
 
         self["options"] = []
 
@@ -307,6 +309,8 @@ def parse(buf, group=None):
             rule[name] += [v.strip() for v in val.split(",")]
         elif name == "flowbits":
             rule.flowbits.append(val)
+            if val.find("noalert") > -1:
+                rule["noalert"] = True
         elif name == "reference":
             rule.references.append(val)
         elif name == "msg":

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -120,50 +120,6 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule = suricata.update.rule.parse(rule_string)
         self.assertTrue(rule["noalert"])
 
-    def test_add_option(self):
-        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string, "local.rules")
-        rule = suricata.update.rule.add_option(
-            rule, "msg", "\"This is a test description.\"", 0)
-        self.assertEqual("This is a test description.", rule["msg"])
-        self.assertEqual("local.rules", rule["group"])
-
-    def test_remove_option(self):
-        rule_string = u"""alert ip any any -> any any (msg:"TEST MESSAGE"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string, "local.rules")
-
-        rule = suricata.update.rule.remove_option(rule, "msg")
-        self.assertEqual("", rule["msg"])
-
-        rule = suricata.update.rule.remove_option(rule, "classtype")
-        self.assertEqual(None, rule["classtype"])
-
-    def test_remove_tag_option(self):
-        rule_string = u"""alert ip any any -> any any (msg:"TEST RULE"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string)
-        self.assertIsNotNone(rule)
-        print(rule["options"])
-
-    def test_scratch(self):
-        rule_string = """alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"ET CURRENT_EVENTS Request to .in FakeAV Campaign June 19 2012 exe or zip"; flow:established,to_server; content:"setup."; fast_pattern:only; http_uri; content:".in|0d 0a|"; flowbits:isset,somebit; flowbits:unset,otherbit; http_header; pcre:"/\/[a-f0-9]{16}\/([a-z0-9]{1,3}\/)?setup\.(exe|zip)$/U"; pcre:"/^Host\x3a\s.+\.in\r?$/Hmi"; metadata:stage,hostile_download; reference:url,isc.sans.edu/diary/+Vulnerabilityqueerprocessbrittleness/13501; classtype:trojan-activity; sid:2014929; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string)
-        self.assertEqual(rule_string, str(rule))
-
-        options = []
-        for option in rule["options"]:
-            if option["value"] is None:
-                options.append(option["name"])
-            else:
-                options.append("%s:%s" % (option["name"], option["value"]))
-
-        reassembled = "%s (%s)" % (rule["header"], rule.rebuild_options())
-
-        print("")
-        print("%s" % rule_string)
-        print("%s" % reassembled)
-
-        self.assertEqual(rule_string, reassembled)
-        
     def test_parse_message_with_semicolon(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST RULE\; and some"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)
@@ -171,12 +127,7 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         self.assertEqual(rule.msg, "TEST RULE\; and some")
 
         # Look for the expected content.
-        found=False
-        for o in rule.options:
-            if o["name"] == "content" and o["value"] == '"uid=0|28|root|29|"':
-                found=True
-                break
-        self.assertTrue(found)
+        self.assertEqual("TEST RULE\; and some", rule["msg"])
 
     def test_parse_message_with_colon(self):
         rule_string = u"""alert tcp 93.174.88.0/21 any -> $HOME_NET any (msg:"SN: Inbound TCP traffic from suspect network (AS29073 - NL)"; flags:S; reference:url,https://suspect-networks.io/networks/cidr/13/; threshold: type limit, track by_dst, seconds 30, count 1; classtype:misc-attack; sid:71918985; rev:1;)"""

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -111,6 +111,15 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule = suricata.update.rule.parse(rule_string)
         self.assertEqual("", rule["msg"])
 
+    def test_noalert(self):
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertFalse(rule["noalert"])
+
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:noalert; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertTrue(rule["noalert"])
+
     def test_add_option(self):
         rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string, "local.rules")


### PR DESCRIPTION
Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2791

These PR stops recording all the rule options into a list.  That is left over from idstools that have some library support for modifying rules that is not required by Suricata  updating. In my tests, removing this improved memory usage by 10-20%.