### PR TITLE
Issue 2791 - optimize memory usage - v2

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -566,75 +566,76 @@ def load_dist_rules(files):
                 logger.error("Failed to open %s: %s" % (path, err))
                 sys.exit(1)
 
-def build_report(prev_rulemap, rulemap):
-    """Build a report of changes between 2 rulemaps.
-
-    Returns a dict with the following keys that each contain a list of
-    rules.
-    - added
-    - removed
-    - modified
-    """
-    report = {
-        "added": [],
-        "removed": [],
-        "modified": []
-    }
-
-    for key in rulemap:
-        rule = rulemap[key]
-        if not rule.id in prev_rulemap:
-            report["added"].append(rule)
-        elif rule.format() != prev_rulemap[rule.id].format():
-            report["modified"].append(rule)
-    for key in prev_rulemap:
-        rule = prev_rulemap[key]
-        if not rule.id in rulemap:
-            report["removed"].append(rule)
-
-    return report
-
 def write_merged(filename, rulemap):
 
     if not args.quiet:
-        prev_rulemap = {}
+        # List of rule IDs that have been added.
+        added = []
+        # List of rule objects that have been removed.
+        removed = []
+        # List of rule IDs that have been modified.
+        modified = []
+
+        oldset = {}
         if os.path.exists(filename):
-            prev_rulemap = build_rule_map(
-                suricata.update.rule.parse_file(filename))
-        report = build_report(prev_rulemap, rulemap)
+            for rule in suricata.update.rule.parse_file(filename):
+                oldset[rule.id] = True
+                if not rule.id in rulemap:
+                    removed.append(rule)
+                elif rule.format() != rulemap[rule.id].format():
+                    modified.append(rulemap[rule.id])
+        for key in rulemap:
+            if not key in oldset:
+                added.append(key)
+
         enabled = len([rule for rule in rulemap.values() if rule.enabled])
         logger.info("Writing rules to %s: total: %d; enabled: %d; "
                     "added: %d; removed %d; modified: %d" % (
                         filename,
                         len(rulemap),
                         enabled,
-                        len(report["added"]),
-                        len(report["removed"]),
-                        len(report["modified"])))
+                        len(added),
+                        len(removed),
+                        len(modified)))
     
     with io.open(filename, encoding="utf-8", mode="w") as fileobj:
         for rule in rulemap:
             print(rulemap[rule].format(), file=fileobj)
 
 def write_to_directory(directory, files, rulemap):
+    # List of rule IDs that have been added.
+    added = []
+    # List of rule objects that have been removed.
+    removed = []
+    # List of rule IDs that have been modified.
+    modified = []
+
+    oldset = {}
     if not args.quiet:
-        previous_rulemap = {}
         for filename in files:
             outpath = os.path.join(
                 directory, os.path.basename(filename))
+
             if os.path.exists(outpath):
-                previous_rulemap.update(build_rule_map(
-                    suricata.update.rule.parse_file(outpath)))
-        report = build_report(previous_rulemap, rulemap)
+                for rule in suricata.update.rule.parse_file(outpath):
+                    oldset[rule.id] = True
+                    if not rule.id in rulemap:
+                        removed.append(rule)
+                    elif rule.format() != rulemap[rule.id].format():
+                        modified.append(rule.id)
+        for key in rulemap:
+            if not key in oldset:
+                added.append(rule.id)
+
         enabled = len([rule for rule in rulemap.values() if rule.enabled])
         logger.info("Writing rule files to directory %s: total: %d; "
                     "enabled: %d; added: %d; removed %d; modified: %d" % (
                         directory,
                         len(rulemap),
                         enabled,
-                        len(report["added"]),
-                        len(report["removed"]),
-                        len(report["modified"])))
+                        len(added),
+                        len(removed),
+                        len(modified)))
 
     for filename in sorted(files):
         outpath = os.path.join(

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -286,14 +286,8 @@ class DropRuleFilter(object):
     def __init__(self, matcher):
         self.matcher = matcher
 
-    def is_noalert(self, rule):
-        for option in rule.options:
-            if option["name"] == "flowbits" and option["value"] == "noalert":
-                return True
-        return False
-
     def match(self, rule):
-        if self.is_noalert(rule):
+        if rule["noalert"]:
             return False
         return self.matcher.match(rule)
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1425,6 +1425,14 @@ def _main():
         notes.dump_notes()
         return 0
 
+    # Set these containers to None to fee the memory before testing Suricata which
+    # may consume a lot of memory by itself. Ideally we should refactor this large
+    # function into multiple methods so these go out of scope and get removed
+    # automatically.
+    rulemap = None
+    rules = None
+    files = None
+
     if not test_suricata(suricata_path):
         logger.error("Suricata test failed, aborting.")
         logger.error("Restoring previous rules.")

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -106,8 +106,6 @@ class Rule(dict):
         self["priority"] = 0
         self["noalert"] = False
 
-        self["options"] = []
-
         self["raw"] = None
 
     def __getattr__(self, name):
@@ -149,40 +147,6 @@ class Rule(dict):
 
     def format(self):
         return u"%s%s" % (u"" if self.enabled else u"# ", self.raw)
-
-    def rebuild_options(self):
-        """ Rebuild the rule options from the list of options."""
-        options = []
-        for option in self.options:
-            if option["value"] is None:
-                options.append(option["name"])
-            else:
-                options.append("%s:%s" % (option["name"], option["value"]))
-        return "%s;" % "; ".join(options)
-
-def remove_option(rule, name):
-    rule["options"] = [
-        option for option in rule["options"] if option["name"] != name]
-    new_rule_string = "%s%s (%s)" % (
-        "" if rule.enabled else "# ",
-        rule["header"].strip(),
-        rule.rebuild_options());
-    return parse(new_rule_string, rule["group"])
-
-def add_option(rule, name, value, index=None):
-    option = {
-        "name": name,
-        "value": value,
-    }
-    if index is None:
-        rule["options"].append(option)
-    else:
-        rule["options"].insert(index, option)
-    new_rule_string = "%s%s (%s)" % (
-        "" if rule.enabled else "# ",
-        rule["header"].strip(),
-        rule.rebuild_options())
-    return parse(new_rule_string, rule["group"])
 
 def find_opt_end(options):
     """ Find the end of an option (;) handling escapes. """
@@ -295,11 +259,6 @@ def parse(buf, group=None):
         else:
             name = option
             val = None
-
-        rule["options"].append({
-            "name": name,
-            "value": val,
-        })
 
         if name in ["gid", "sid", "rev"]:
             rule[name] = int(val)

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -75,6 +75,7 @@ class Rule(dict):
     - **references**: References as a list
     - **classtype**: The classification type
     - **priority**: The rule priority, 0 if not provided
+    - **noalert**: Is the rule a noalert rule
     - **raw**: The raw rule as read from the file or buffer
 
     :param enabled: Optional parameter to set the enabled state of the rule
@@ -103,6 +104,7 @@ class Rule(dict):
         self["references"] = []
         self["classtype"] = None
         self["priority"] = 0
+        self["noalert"] = False
 
         self["options"] = []
 
@@ -307,6 +309,8 @@ def parse(buf, group=None):
             rule[name] += [v.strip() for v in val.split(",")]
         elif name == "flowbits":
             rule.flowbits.append(val)
+            if val.find("noalert") > -1:
+                rule["noalert"] = True
         elif name == "reference":
             rule.references.append(val)
         elif name == "msg":

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -120,50 +120,6 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule = suricata.update.rule.parse(rule_string)
         self.assertTrue(rule["noalert"])
 
-    def test_add_option(self):
-        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string, "local.rules")
-        rule = suricata.update.rule.add_option(
-            rule, "msg", "\"This is a test description.\"", 0)
-        self.assertEqual("This is a test description.", rule["msg"])
-        self.assertEqual("local.rules", rule["group"])
-
-    def test_remove_option(self):
-        rule_string = u"""alert ip any any -> any any (msg:"TEST MESSAGE"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string, "local.rules")
-
-        rule = suricata.update.rule.remove_option(rule, "msg")
-        self.assertEqual("", rule["msg"])
-
-        rule = suricata.update.rule.remove_option(rule, "classtype")
-        self.assertEqual(None, rule["classtype"])
-
-    def test_remove_tag_option(self):
-        rule_string = u"""alert ip any any -> any any (msg:"TEST RULE"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string)
-        self.assertIsNotNone(rule)
-        print(rule["options"])
-
-    def test_scratch(self):
-        rule_string = """alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"ET CURRENT_EVENTS Request to .in FakeAV Campaign June 19 2012 exe or zip"; flow:established,to_server; content:"setup."; fast_pattern:only; http_uri; content:".in|0d 0a|"; flowbits:isset,somebit; flowbits:unset,otherbit; http_header; pcre:"/\/[a-f0-9]{16}\/([a-z0-9]{1,3}\/)?setup\.(exe|zip)$/U"; pcre:"/^Host\x3a\s.+\.in\r?$/Hmi"; metadata:stage,hostile_download; reference:url,isc.sans.edu/diary/+Vulnerabilityqueerprocessbrittleness/13501; classtype:trojan-activity; sid:2014929; rev:1;)"""
-        rule = suricata.update.rule.parse(rule_string)
-        self.assertEqual(rule_string, str(rule))
-
-        options = []
-        for option in rule["options"]:
-            if option["value"] is None:
-                options.append(option["name"])
-            else:
-                options.append("%s:%s" % (option["name"], option["value"]))
-
-        reassembled = "%s (%s)" % (rule["header"], rule.rebuild_options())
-
-        print("")
-        print("%s" % rule_string)
-        print("%s" % reassembled)
-
-        self.assertEqual(rule_string, reassembled)
-        
     def test_parse_message_with_semicolon(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST RULE\; and some"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)
@@ -171,12 +127,7 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         self.assertEqual(rule.msg, "TEST RULE\; and some")
 
         # Look for the expected content.
-        found=False
-        for o in rule.options:
-            if o["name"] == "content" and o["value"] == '"uid=0|28|root|29|"':
-                found=True
-                break
-        self.assertTrue(found)
+        self.assertEqual("TEST RULE\; and some", rule["msg"])
 
     def test_parse_message_with_colon(self):
         rule_string = u"""alert tcp 93.174.88.0/21 any -> $HOME_NET any (msg:"SN: Inbound TCP traffic from suspect network (AS29073 - NL)"; flags:S; reference:url,https://suspect-networks.io/networks/cidr/13/; threshold: type limit, track by_dst, seconds 30, count 1; classtype:misc-attack; sid:71918985; rev:1;)"""

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -111,6 +111,15 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule = suricata.update.rule.parse(rule_string)
         self.assertEqual("", rule["msg"])
 
+    def test_noalert(self):
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertFalse(rule["noalert"])
+
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:noalert; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertTrue(rule["noalert"])
+
     def test_add_option(self):
         rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string, "local.rules")


### PR DESCRIPTION
Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2791

Previous PR:
- https://github.com/OISF/suricata-update/pull/95

Changes from last PR:
- When building the mini-report of rule updates, only track IDs when we can to limit the amount of memory used.
- Set some collections to None to free memory before starting up Suricata in test mode.
