### PR TITLE
Fix null pointer dereference issue detected by coverity

### DIFF
--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -268,7 +268,7 @@ def parse(buf, group=None):
             rule[name] += [v.strip() for v in val.split(",")]
         elif name == "flowbits":
             rule.flowbits.append(val)
-            if val.find("noalert") > -1:
+            if val and val.find("noalert") > -1:
                 rule["noalert"] = True
         elif name == "reference":
             rule.references.append(val)


### PR DESCRIPTION
Coverity scan of the current code raised the following issue:
```
>>>     CID 327298:  Null pointer dereferences  (FORWARD_NULL)
>>>     Accessing a property of null-like value "val".
271                 if val.find("noalert") > -1:
```

Fix this by adding a null check on val.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2834