### PR TITLE
Fix TypeError : Failure with missing rule params

### DIFF
--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -118,7 +118,13 @@ class Rule(dict):
         :returns: A tuple (gid, sid) representing the ID of the rule
         :rtype: A tuple of 2 ints
         """
-        return (int(self.gid), int(self.sid))
+        self_gid=self.gid
+        self_sid=self.sid
+        if self.gid is not None:
+            self_gid=int(self_gid)
+        if self.sid is not None:
+            self_sid=int(self_sid)
+        return (self_gid, self_sid)
 
     @property
     def idstr(self):

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -118,13 +118,7 @@ class Rule(dict):
         :returns: A tuple (gid, sid) representing the ID of the rule
         :rtype: A tuple of 2 ints
         """
-        self_gid=self.gid
-        self_sid=self.sid
-        if self.gid is not None:
-            self_gid=int(self_gid)
-        if self.sid is not None:
-            self_sid=int(self_sid)
-        return (self_gid, self_sid)
+        return (int(self.gid), int(self.sid))
 
     @property
     def idstr(self):
@@ -160,6 +154,10 @@ def find_opt_end(options):
 
     while True:
         i = options[offset:].find(";")
+        if(options[offset:i+1].find("classtype")!=-1):
+            j=options[offset+2:].find(" ")
+            if(j!=-1):
+                i=j
         if options[offset + i - 1] == "\\":
             offset += 2
         else:


### PR DESCRIPTION
Issue : If someone by mistake forgets a semicolon or changes a rule to not have a gid or sid, it leads to the following error:
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

- [Done ] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ Done] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [Not Applicable ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine] ticket: https://redmine.openinfosecfoundation.org/issues/2867

Describe changes:
- This issue can be fixed by adding a check to make sure before converting them to int that self.gid and self.sid are not NoneType.
