### PR TITLE
Optimization : Catch control-c (KeyboardInterrupt) and exit cleanly.

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1454,10 +1454,15 @@ def _main():
 
 def main():
     try:
-        sys.exit(_main())
-    except exceptions.ApplicationError as err:
-        logger.error(err)
-    sys.exit(1)
+        try:
+            sys.exit(_main())
+        except exceptions.ApplicationError as err:
+            logger.error(err)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("Program interrupted by keyboard, aborting.")
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
Optimization #2878
Catch control-c (KeyboardInterrupt) and exit cleanly.

Changes:
-This problem can be dealt with by adding a try except statement in the main() function.
-Here if the problem statement detects a KeyboardInterrupt it would print Program interrupted by keyboard, aborting. instead of showing traceback of what it was executing.

Checklist:
- [Done ] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [Done ] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ Not Applicable] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to redmine :
https://redmine.openinfosecfoundation.org/issues/2878

