### PR TITLE
Optimization : Catch control-c (KeyboardInterrupt) and exit cleanly. #2

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -32,6 +32,8 @@ import shutil
 import glob
 import io
 import tempfile
+import signal
+
 
 try:
     # Python 3.
@@ -1452,7 +1454,12 @@ def _main():
 
     return 0
 
+def signal_handler(signal, frame):
+    print('Program interrupted by keyboard, aborting.')
+    sys.exit(0)
+
 def main():
+    signal.signal(signal.SIGINT, signal_handler)
     try:
         sys.exit(_main())
     except exceptions.ApplicationError as err:


### PR DESCRIPTION
Optimization #2878 
Catch control-c (KeyboardInterrupt) and exit cleanly.

Can be done by importing python library signal, and defining a function
signal_handler which will print a message if keyboard interrupt is
detected and exit the program.

Checklist:

[Done ] I have read the contributing guide lines at
https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
[Done ] I have signed the Open Information Security Foundation
contribution agreement at
https://suricata-ids.org/about/contribution-agreement/
[ Not Applicable] I have updated the user guide (in doc/userguide/) to reflect the
changes made (if applicable)

Link to redmine :
https://redmine.openinfosecfoundation.org/issues/2878
