### PR TITLE
Fix Failure with --no-merge

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -626,7 +626,7 @@ def write_to_directory(directory, files, rulemap):
                         modified.append(rule.id)
         for key in rulemap:
             if not key in oldset:
-                added.append(rule.id)
+                added.append(key)
 
         enabled = len([rule for rule in rulemap.values() if rule.enabled])
         logger.info("Writing rule files to directory %s: total: %d; "


### PR DESCRIPTION
UnboundLocalError: local variable 'rule' referenced before assignment

Running into an issue when I run 'suricata-update --no-merge'.
Fixed by changing 'rule.id' to 'key' variable since 'rule' is not used in the
loop.'key' is appended to added list i.e. List of rule IDs that have been added.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-
