### PR TITLE
Fix TypeError : Failure with missing rule params #3

### DIFF
--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -118,7 +118,11 @@ class Rule(dict):
         :returns: A tuple (gid, sid) representing the ID of the rule
         :rtype: A tuple of 2 ints
         """
-        return (int(self.gid), int(self.sid))
+        try:
+            return (int(self.gid), int(self.sid))
+        except TypeError:
+            logger.error("sid or gid can't be null, exiting.")
+            sys.exit(1)
 
     @property
     def idstr(self):


### PR DESCRIPTION
Bug #2867 : Failure with missing rule params
Issue : If someone by mistake forgets a semicolon or changes a rule to not have a gid or sid, it leads to the following error:
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

To correct this I added a try-except statement in rule.py which would
raise an error if sid or gid are of type None because of incorrect
parsing of a rule.

- [x]  I have read the contributing guide lines at
https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x]  I have signed the Open Information Security Foundation
contribution agreement at
https://suricata-ids.org/about/contribution-agreement/
- [ ]  I have updated the user guide (in doc/userguide/) to reflect the
changes made (if applicable)
Link to [redmine] ticket: https://redmine.openinfosecfoundation.org/issues/2867
