### PR TITLE
Fix TypeError : Failure with missing rule params #4

### DIFF
--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -286,6 +286,9 @@ def parse(buf, group=None):
 
     return rule
 
+class BadSidError(Exception):
+    """Raises exception when sid is of type null"""
+
 def parse_fileobj(fileobj, group=None):
     """ Parse multiple rules from a file like object.
 
@@ -310,7 +313,13 @@ def parse_fileobj(fileobj, group=None):
         try:
             rule = parse(buf, group)
             if rule:
-                rules.append(rule)
+                try:
+                    if rule["sid"]!=None:
+                        rules.append(rule)
+                    else:
+                        raise BadSidError("Sid cannot be of type null")
+                except BadSidError as err:
+                    logger.error("Failed to parse rule: %s: %s", buf.rstrip(), err)
         except Exception as err:
             logger.error("Failed to parse rule: %s: %s", buf.rstrip(), err)
         buf = ""


### PR DESCRIPTION
Bug #2867 : Failure with missing rule params
Issue : If someone by mistake forgets a semicolon or changes a rule to not have a gid or sid, it leads to the following error:
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

To correct this, after the rule is parsed, it is checked to make sure that the sid is not of type None and if it is, then a BadSidError exception is raised and the rule is not added to the final list.

- [x] I have read the contributing guide lines at
https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
contribution agreement at
https://suricata-ids.org/about/contribution-agreement/
 - [x] I have updated the user guide (in doc/userguide/) to reflect the
changes made (if applicable)
Link to [redmine] ticket: https://redmine.openinfosecfoundation.org/issues/2867

