### PR TITLE
Fix default for the --ignore flag

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1102,7 +1102,7 @@ def _main():
                                help="Filename of drop rules filters")
     
     update_parser.add_argument("--ignore", metavar="<pattern>", action="append",
-                               default=[],
+                               default=None,
                                help="Filenames to ignore (can be specified multiple times; default: *deleted.rules)")
     update_parser.add_argument("--no-ignore", action="store_true",
                                default=False,


### PR DESCRIPTION
suricata-update doesn't properly load some sections in update.yaml file. 
Example: 
Even after setting the following in update.yaml
```
ignore:
  - "*deleted.rules" 
  - "*pop3.rules"
```

```
$ ./bin/suricata-update -v
```
generates
```
16/3/2019 -- 03:14:59 - <Debug> -- Parsing rules/emerging-pop3.rules.
16/3/2019 -- 03:15:01 - <Debug> -- Parsing rules/emerging-deleted.rules.
```
which means the files do not get ignored. It seems that the code loading command line parameters override previous settings even when no parameters are given. 

Thus changing the default for the --ignore flag from "[]" to "None", fixes the issue.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
[https://redmine.openinfosecfoundation.org/issues/2851](url)
Describe changes:
Fixes default for the --ignore flag from "[]" to "None"
