### PR TITLE
Add KeyboardInterrupt error handling

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1458,6 +1458,9 @@ def main():
         sys.exit(_main())
     except exceptions.ApplicationError as err:
         logger.error(err)
+    except KeyboardInterrupt:
+        print("\nProgram interrupted by keyboard, aborting.")
+        sys.exit(1)
     sys.exit(1)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes Bug #2878.
Add a KeyboardInterrupt Interrupt Handler inside the try catch
statement of the main program. Thus if a user will use `Ctrl+C`
to kill the updater it will get the following message:
"Program interrupted by keyboard, aborting.".

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#2878](https://redmine.openinfosecfoundation.org/issues/2878)

Describe changes:
- When a user sends a kill signal (interrupts the program) using `Ctrl+C` the trace isn't shown anymore but instead the informative message "Program interrupted by keyboard, aborting".
- Changes involved on the `main.py` by adding an Exception Handler inside the try-catch main loop.
