### PR TITLE
Cleanup unused import and use isinstance() instead of type()

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -27,7 +27,6 @@ import time
 import hashlib
 import fnmatch
 import subprocess
-import types
 import shutil
 import glob
 import io
@@ -975,7 +974,7 @@ def load_sources(suricata_version):
 
     if config.get("sources"):
         for url in config.get("sources"):
-            if type(url) not in [type("")]:
+            if not isinstance(url, str):
                 raise exceptions.InvalidConfigurationError(
                     "Invalid datatype for source URL: %s" % (str(url)))
             url = url % internal_params


### PR DESCRIPTION
Optimization Cleanup main imports

`import types` is an unused import in main.py, therefore, removed.
Also, using `isinstance()` is the preferred way to access the type.
The isinstance() function checks if the object (first argument)
is an instance or subclass of classinfo class (second argument).
Here object is the 'url' to be checked and classinfo is a string
type.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2872

Describe changes:
-
-
-
