### PR TITLE
Bring parsers out of the main function

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1017,8 +1017,8 @@ def check_output_directory(output_dir):
             raise exceptions.ApplicationError(
                 "Failed to create directory %s: %s" % (
                     output_dir, err))
-
-def _main():
+           
+def parse_args():
     global args
 
     default_update_yaml = config.DEFAULT_UPDATE_YAML_PATH
@@ -1179,7 +1179,10 @@ def _main():
             setattr(args, arg, getattr(global_args, arg))
         elif hasattr(args, arg) and getattr(args, arg) is None:
             setattr(args, arg, getattr(global_args, arg))
-
+    
+def _main():
+    parse_args()
+    
     # Go verbose or quiet sooner than later.
     if args.verbose:
         logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
In an attempt to make the main function code cleaner and compact, separate the parsers out by defining a function parse_args(). Since the args variable is a global variable, the simplest approach is to define a new function and make a function call to it from main.

Closes Redmine ticket, Optimization #2874

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
[https://redmine.openinfosecfoundation.org/issues/2874](url)
Describe changes:
Define a new function parse_args() to bring the parsers out of main function and make a call from main function. 
