### PR TITLE
make sure that noalert is set in newly enabled rules

### DIFF
--- a/doc/common-options.rst
+++ b/doc/common-options.rst
@@ -44,3 +44,7 @@
 .. option:: --user-agent <string>
 
    Set a custom user agent string for HTTP requests.
+
+.. option:: --flowbit-no-alert
+
+   Previously disabled rules enabled by flowbit dependencies will receive the flowbits:noalert option.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -724,6 +724,8 @@ def resolve_flowbits(rulemap, disabled_rules):
                     "Enabling previously disabled rule for flowbits: %s" % (
                         rule.brief()))
             rule.enabled = True
+            if config.get("flowbit-no-alert"):
+                rule.noalert = True
             flowbit_enabled.add(rule)
     logger.info("Enabled %d rules for flowbit dependencies." % (
         len(flowbit_enabled)))
@@ -1125,6 +1127,8 @@ def _main():
                                help="Command to test Suricata configuration")
     update_parser.add_argument("--no-test", action="store_true", default=False,
                                help="Disable testing rules with Suricata")
+    update_parser.add_argument("--flowbit-no-alert", action="store_true", default=False,
+                               help="Previously disabled rules enabled by flowbit dependencies will receive the flowbits:noalert option")
     
     update_parser.add_argument("--no-merge", action="store_true", default=False,
                                help="Do not merge the rules into a single file")

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -34,6 +34,8 @@ import re
 import logging
 import io
 
+from suricata.update import config
+
 logger = logging.getLogger(__name__)
 
 # Compile an re pattern for basic rule matching.
@@ -146,6 +148,8 @@ class Rule(dict):
         return self.format()
 
     def format(self):
+        if config.get("flowbit-no-alert") and self.noalert and not "noalert;" in self.raw:
+            self.raw = re.sub(r'\)$', " flowbits:noalert;)", self.raw)
         return u"%s%s" % (u"" if self.enabled else u"# ", self.raw)
 
 def find_opt_end(options):


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2906

Describe changes:
- This commit adds functionality that ensures that previously
disabled rules enabled by flowbit dependencies will receive
the flowbits:noalert option, if --flowbit-no-alert option is set.
