### PR TITLE
Fix TypeError : Failure with missing rule params

### DIFF
--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -286,6 +286,9 @@ def parse(buf, group=None):
 
     return rule
 
+class BadSidError(Exception):
+    """Raises exception when sid is of type null"""
+
 def parse_fileobj(fileobj, group=None):
     """ Parse multiple rules from a file like object.
 
@@ -310,6 +313,8 @@ def parse_fileobj(fileobj, group=None):
         try:
             rule = parse(buf, group)
             if rule:
+                if not rule["sid"]:
+                    raise BadSidError("Sid cannot be of type null")
                 rules.append(rule)
         except Exception as err:
             logger.error("Failed to parse rule: %s: %s", buf.rstrip(), err)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -71,8 +71,8 @@ class RuleTestCase(unittest.TestCase):
         self.assertEqual(str(rule), """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)""")
 
     def test_parse_fileobj(self):
-        rule_buf = ("""# alert tcp $HOME_NET any -> $EXTERNAL_NET any """
-                    """(msg:"some message";)""")
+        rule_buf = ("""alert ( msg:"DECODE_NOT_IPV4_DGRAM"; sid:1; gid:116; rev:1; metadata:rule-type decode; classtype:protocol-command-decode;) """
+                    """alert ( msg:"DECODE_NOT_IPV4_DGRAM"; sid:1; gid:116; rev:1; metadata:rule-type decode; classtype:protocol-command-decode;)""")
         fileobj = io.StringIO()
         for i in range(2):
             fileobj.write(u"%s\n" % rule_buf)
@@ -81,14 +81,24 @@ class RuleTestCase(unittest.TestCase):
         self.assertEqual(2, len(rules))
 
     def test_parse_file(self):
-        rule_buf = ("""# alert tcp $HOME_NET any -> $EXTERNAL_NET any """
-                    """(msg:"some message";)""")
+        rule_buf = ("""alert ( msg:"DECODE_NOT_IPV4_DGRAM"; sid:1; gid:116; rev:1; metadata:rule-type decode; classtype:protocol-command-decode;) """
+                    """alert ( msg:"DECODE_NOT_IPV4_DGRAM"; sid:1; gid:116; rev:1; metadata:rule-type decode; classtype:protocol-command-decode;)""")
         tmp = tempfile.NamedTemporaryFile()
         for i in range(2):
             tmp.write(("%s\n" % rule_buf).encode())
         tmp.flush()
         rules = suricata.update.rule.parse_file(tmp.name)
         self.assertEqual(2, len(rules))
+
+    def test_parse_rule_with_sid_error(self):
+        rule_buf = ("""# alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"some message";)"""
+                    """alert ( msg:"DECODE_NOT_IPV4_DGRAM" sid:1; gid:116; rev:1; metadata:rule-type decode; classtype:protocol-command-decode;)""")
+        fileobj = io.StringIO()
+        for i in range(2):
+            fileobj.write(u"%s\n" % rule_buf)
+        fileobj.seek(0)
+        rules = suricata.update.rule.parse_fileobj(fileobj)
+        self.assertEqual(0, len(rules))
 
     def test_parse_file_with_unicode(self):
         rules = suricata.update.rule.parse_file("./tests/rule-with-unicode.rules")


### PR DESCRIPTION
Bug #2867 : Failure with missing rule params
Issue : If someone by mistake forgets a semicolon or changes a rule to not have a gid or sid, it leads to the following error:
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

To correct this, after the rule is parsed, it is checked to make sure that the sid is not of type None and if it is, then a BadSidError exception is raised and the rule is not added to the final list.

- [x]  I have read the contributing guide lines at
https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x]  I have signed the Open Information Security Foundation
contribution agreement at
https://suricata-ids.org/about/contribution-agreement/
- [x]  I have updated the user guide (in doc/userguide/) to reflect the
changes made (if applicable)
Link to [redmine] ticket: https://redmine.openinfosecfoundation.org/issues/2867
