### PR TITLE
Matchers 2873 v3 : Separate out Matchers

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -32,7 +32,11 @@ import shutil
 import glob
 import io
 import tempfile
-import matchers
+
+if (__name__ == "__main__"):
+    import matchers
+else:
+    from suricata.update import matchers
 
 try:
     # Python 3.

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1120,7 +1120,7 @@ def _main():
                 if not suriconf.is_true(key, ["detection-only"]):
                     proto = key.split(".")[2]
                     logger.info("Disabling rules with proto %s", proto)
-                    disable_matchers.append(ProtoRuleMatcher(proto))
+                    disable_matchers.append(matchers.ProtoRuleMatcher(proto))
 
     # Check that the cache directory exists and is writable.
     if not os.path.exists(config.get_cache_dir()):

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -250,16 +250,13 @@ def load_filters(filename):
 
 def load_drop_filters(filename):
     
-    matchers = matchers.load_matchers(filename)
+    match = matchers.load_matchers(filename)
     filters = []
 
-    for matcher in matchers:
+    for matcher in match:
         filters.append(DropRuleFilter(matcher))
 
     return filters
-
-
-
 
 
 def load_local(local, files):

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -93,49 +93,6 @@ DEFAULT_SURICATA_VERSION = "4.0.0"
 DEFAULT_OUTPUT_RULE_FILENAME = "suricata.rules"
 
 
-class ModifyRuleFilter(object):
-    """Filter to modify an idstools rule object.
-
-    Important note: This filter does not modify the rule inplace, but
-    instead returns a new rule object with the modification.
-    """
-
-    def __init__(self, matcher, pattern, repl):
-        self.matcher = matcher
-        self.pattern = pattern
-        self.repl = repl
-
-    def match(self, rule):
-        return self.matcher.match(rule)
-
-    def filter(self, rule):
-        modified_rule = self.pattern.sub(self.repl, rule.format())
-        parsed = suricata.update.rule.parse(modified_rule, rule.group)
-        if parsed is None:
-            logger.error("Modification of rule %s results in invalid rule: %s",
-                         rule.idstr, modified_rule)
-            return rule
-        return parsed
-
-    @classmethod
-    def parse(cls, buf):
-        tokens = shlex.split(buf)
-        if len(tokens) == 3:
-            matchstring, a, b = tokens
-        elif len(tokens) > 3 and tokens[0] == "modifysid":
-            matchstring, a, b = tokens[1], tokens[2], tokens[4]
-        else:
-            raise Exception("Bad number of arguments.")
-        matcher = matchers.parse_rule_match(matchstring)
-        if not matcher:
-            raise Exception("Bad match string: %s" % (matchstring))
-        pattern = re.compile(a)
-
-        # Convert Oinkmaster backticks to Python.
-        b = re.sub("\$\{(\d+)\}", "\\\\\\1", b)
-
-        return cls(matcher, pattern, b)
-
 class DropRuleFilter(object):
     """ Filter to modify an idstools rule object to a drop rule. """
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -89,14 +89,6 @@ DEFAULT_SURICATA_VERSION = "4.0.0"
 DEFAULT_OUTPUT_RULE_FILENAME = "suricata.rules"
 
 
-
-
-
-
-
-
-
-
 class ModifyRuleFilter(object):
     """Filter to modify an idstools rule object.
 
@@ -130,7 +122,7 @@ class ModifyRuleFilter(object):
             matchstring, a, b = tokens[1], tokens[2], tokens[4]
         else:
             raise Exception("Bad number of arguments.")
-        matcher = parse_rule_match(matchstring)
+        matcher = matchers.parse_rule_match(matchstring)
         if not matcher:
             raise Exception("Bad match string: %s" % (matchstring))
         pattern = re.compile(a)

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -1,0 +1,211 @@
+# Copyright (C) 2017 Open Information Security Foundation
+# Copyright (c) 2013 Jason Ish
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+"""Module for separating out matchers code."""
+
+class AllRuleMatcher(object):
+    """Matcher object to match all rules. """
+
+    def match(self, rule):
+        return True
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.strip() == "*":
+            return cls()
+        return None
+
+class ProtoRuleMatcher:
+    """A rule matcher that matches on the protocol of a rule."""
+
+    def __init__(self, proto):
+        self.proto = proto
+
+    def match(self, rule):
+        return rule.proto == self.proto
+
+class IdRuleMatcher(object):
+    """Matcher object to match an idstools rule object by its signature
+    ID."""
+
+    def __init__(self, generatorId=None, signatureId=None):
+        self.signatureIds = []
+        if generatorId and signatureId:
+            self.signatureIds.append((generatorId, signatureId))
+
+    def match(self, rule):
+        for (generatorId, signatureId) in self.signatureIds:
+            if generatorId == rule.gid and signatureId == rule.sid:
+                return True
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        matcher = cls()
+
+        for entry in buf.split(","):
+            entry = entry.strip()
+
+            parts = entry.split(":", 1)
+            if not parts:
+                return None
+            if len(parts) == 1:
+                try:
+                    signatureId = int(parts[0])
+                    matcher.signatureIds.append((1, signatureId))
+                except:
+                    return None
+            else:
+                try:
+                    generatorId = int(parts[0])
+                    signatureId = int(parts[1])
+                    matcher.signatureIds.append((generatorId, signatureId))
+                except:
+                    return None
+
+        return matcher
+
+class FilenameMatcher(object):
+    """Matcher object to match a rule by its filename. This is similar to
+    a group but has no specifier prefix.
+    """
+
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def match(self, rule):
+        if hasattr(rule, "group") and rule.group is not None:
+            return fnmatch.fnmatch(rule.group, self.pattern)
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.startswith("filename:"):
+            try:
+                group = buf.split(":", 1)[1]
+                return cls(group.strip())
+            except:
+                pass
+        return None
+class GroupMatcher(object):
+    """Matcher object to match an idstools rule object by its group (ie:
+    filename).
+
+    The group is just the basename of the rule file with or without
+    extension.
+
+    Examples:
+    - emerging-shellcode
+    - emerging-trojan.rules
+
+    """
+
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def match(self, rule):
+        if hasattr(rule, "group") and rule.group is not None:
+            if fnmatch.fnmatch(os.path.basename(rule.group), self.pattern):
+                return True
+            # Try matching against the rule group without the file
+            # extension.
+            if fnmatch.fnmatch(
+                    os.path.splitext(
+                        os.path.basename(rule.group))[0], self.pattern):
+                return True
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.startswith("group:"):
+            try:
+                logger.debug("Parsing group matcher: %s" % (buf))
+                group = buf.split(":", 1)[1]
+                return cls(group.strip())
+            except:
+                pass
+        if buf.endswith(".rules"):
+            return cls(buf.strip())
+        return None
+
+class ReRuleMatcher(object):
+    """Matcher object to match an idstools rule object by regular
+    expression."""
+
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def match(self, rule):
+        if self.pattern.search(rule.raw):
+            return True
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.startswith("re:"):
+            try:
+                logger.debug("Parsing regex matcher: %s" % (buf))
+                patternstr = buf.split(":", 1)[1].strip()
+                pattern = re.compile(patternstr, re.I)
+                return cls(pattern)
+            except:
+                pass
+        return None
+
+
+def parse_rule_match(match):
+    matcher = AllRuleMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = IdRuleMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = ReRuleMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = FilenameMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = GroupMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    return None
+
+def parse_matchers(fileobj):
+    matchers = []
+
+    for line in fileobj:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = line.rsplit(" #")[0]
+        matcher = parse_rule_match(line)
+        if not matcher:
+            logger.warn("Failed to parse: \"%s\"" % (line))
+        else:
+            matchers.append(matcher)
+
+    return matchers
+
+def load_matchers(filename):
+    with open(filename) as fileobj:
+        return parse_matchers(fileobj)

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -16,6 +16,7 @@
 # 02110-1301, USA.
 
 """Module for separating out matchers code."""
+import fnmatch
 
 class AllRuleMatcher(object):
     """Matcher object to match all rules. """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,7 @@ import unittest
 
 import suricata.update.rule
 from suricata.update import main
+from suricata.update import matchers
 import suricata.update.extract
 
 class TestRulecat(unittest.TestCase):
@@ -195,7 +196,7 @@ class DropRuleFilterTestCase(unittest.TestCase):
 
     def test_enabled_rule(self):
         rule0 = suricata.update.rule.parse(self.rule_string, "rules/malware.rules")
-        id_matcher = main.IdRuleMatcher.parse("2020757")
+        id_matcher = matchers.IdRuleMatcher.parse("2020757")
         self.assertTrue(id_matcher.match(rule0))
 
         drop_filter = main.DropRuleFilter(id_matcher)
@@ -207,7 +208,7 @@ class DropRuleFilterTestCase(unittest.TestCase):
     def test_disabled_rule(self):
         rule0 = suricata.update.rule.parse(
             "# " + self.rule_string, "rules/malware.rules")
-        id_matcher = main.IdRuleMatcher.parse("2020757")
+        id_matcher = matchers.IdRuleMatcher.parse("2020757")
         self.assertTrue(id_matcher.match(rule0))
 
         drop_filter = main.DropRuleFilter(id_matcher)
@@ -224,11 +225,11 @@ class DropRuleFilterTestCase(unittest.TestCase):
         rule_with_noalert = """alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"ET TROJAN [CrowdStrike] ANCHOR PANDA Torn RAT Beacon Message Header Local"; flow:established, to_server; dsize:16; content:"|00 00 00 11 c8 00 00 00 00 00 00 00 00 00 00 00|"; depth:16; flowbits:set,ET.Torn.toread_header; flowbits: noalert; reference:url,blog.crowdstrike.com/whois-anchor-panda/index.html; classtype:trojan-activity; sid:2016659; rev:2; metadata:created_at 2013_03_22, updated_at 2013_03_22;)"""
 
         rule = suricata.update.rule.parse(rule_without_noalert)
-        matcher = main.IdRuleMatcher.parse("2016659")
+        matcher = matchers.IdRuleMatcher.parse("2016659")
         filter = main.DropRuleFilter(matcher)
         self.assertTrue(filter.match(rule))
 
         rule = suricata.update.rule.parse(rule_with_noalert)
-        matcher = main.IdRuleMatcher.parse("2016659")
+        matcher = matchers.IdRuleMatcher.parse("2016659")
         filter = main.DropRuleFilter(matcher)
         self.assertFalse(filter.match(rule))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,7 +117,7 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
     def test_id_match(self):
         rule0 = suricata.update.rule.parse(self.rule_string)
         line = '2020757 "\|0d 0a\|" "|ff ff|"'
-        rule_filter = main.ModifyRuleFilter.parse(line)
+        rule_filter = matchers.ModifyRuleFilter.parse(line)
         self.assertTrue(rule_filter != None)
         self.assertTrue(rule_filter.match(rule0))
         rule1 = rule_filter.filter(rule0)
@@ -128,7 +128,7 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
     def test_re_match(self):
         rule0 = suricata.update.rule.parse(self.rule_string)
         line = 're:classtype:trojan-activity "\|0d 0a\|" "|ff ff|"'
-        rule_filter = main.ModifyRuleFilter.parse(line)
+        rule_filter = matchers.ModifyRuleFilter.parse(line)
         self.assertTrue(rule_filter != None)
         self.assertTrue(rule_filter.match(rule0))
         rule1 = rule_filter.filter(rule0)
@@ -139,7 +139,7 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
     def test_re_backref_one(self):
         rule0 = suricata.update.rule.parse(self.rule_string)
         line = 're:classtype:trojan-activity "(alert)(.*)" "drop\\2"'
-        filter = main.ModifyRuleFilter.parse(line)
+        filter = matchers.ModifyRuleFilter.parse(line)
         self.assertTrue(filter != None)
         self.assertTrue(filter.match(rule0))
         rule1 = filter.filter(rule0)
@@ -149,7 +149,7 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
     def test_re_backref_two(self):
         rule0 = suricata.update.rule.parse(self.rule_string)
         line = 're:classtype:trojan-activity "(alert)(.*)(from_server)(.*)" "drop\\2to_client\\4"'
-        filter = main.ModifyRuleFilter.parse(line)
+        filter = matchers.ModifyRuleFilter.parse(line)
         self.assertTrue(filter != None)
         self.assertTrue(filter.match(rule0))
         rule1 = filter.filter(rule0)
@@ -160,7 +160,7 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
         rule_in = suricata.update.rule.parse(self.rule_string)
         self.assertIsNotNone(rule_in)
 
-        f = main.ModifyRuleFilter.parse(
+        f = matchers.ModifyRuleFilter.parse(
             'group:emerging-trojan.rules "^alert" "drop"')
         self.assertIsNotNone(f)
 
@@ -168,14 +168,14 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
         self.assertTrue(rule_out.format().startswith("drop"))
 
     def test_oinkmaster_backticks(self):
-        f = main.ModifyRuleFilter.parse(
+        f = matchers.ModifyRuleFilter.parse(
             '* "^drop(.*)noalert(.*)" "alert${1}noalert${2}"')
         rule_in ="""drop http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET MALWARE Windows executable sent when remote host claims to send an image 2"; flow: established,to_client; content:"|0d 0a|Content-Type|3a| image/jpeg|0d 0a 0d 0a|MZ"; fast_pattern:12,20; noalert; classtype:trojan-activity; sid:2020757; rev:2;)"""
         rule_out = f.filter(suricata.update.rule.parse(rule_in))
         self.assertEqual("""alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET MALWARE Windows executable sent when remote host claims to send an image 2"; flow: established,to_client; content:"|0d 0a|Content-Type|3a| image/jpeg|0d 0a 0d 0a|MZ"; fast_pattern:12,20; noalert; classtype:trojan-activity; sid:2020757; rev:2;)""", rule_out.format())
 
     def test_oinkmaster_backticks_not_noalert(self):
-        f = main.ModifyRuleFilter.parse(
+        f = matchers.ModifyRuleFilter.parse(
             'modifysid * "^drop(.*)noalert(.*)" | "alert${1}noalert${2}"')
         rule_in ="""drop http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET MALWARE Windows executable sent when remote host claims to send an image 2"; flow: established,to_client; content:"|0d 0a|Content-Type|3a| image/jpeg|0d 0a 0d 0a|MZ"; fast_pattern:12,20; classtype:trojan-activity; sid:2020757; rev:2;)"""
         rule_out = f.filter(suricata.update.rule.parse(rule_in))
@@ -183,7 +183,7 @@ class ModifyRuleFilterTestCase(unittest.TestCase):
 
     def test_oinkmaster_modify_group_name(self):
         """Test an Oinkmaster style modification line using a group name."""
-        f = main.ModifyRuleFilter.parse(
+        f = matchers.ModifyRuleFilter.parse(
             'modifysid botcc.rules "^alert" | "drop"')
         rule_in ="""alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET MALWARE Windows executable sent when remote host claims to send an image 2"; flow: established,to_client; content:"|0d 0a|Content-Type|3a| image/jpeg|0d 0a 0d 0a|MZ"; fast_pattern:12,20; classtype:trojan-activity; sid:2020757; rev:2;)"""
         rule = suricata.update.rule.parse(rule_in, "rules/botcc.rules")

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -21,6 +21,7 @@ import io
 import unittest
 
 import suricata.update.rule
+from suricata.update import main
 from suricata.update import matchers
 import suricata.update.extract
 
@@ -56,16 +57,16 @@ class LoadMatchersTestCase(unittest.TestCase):
 
     def test_trailing_comment(self):
         """Test loading matchers with a trailing comment."""
-        matchers = matchers.parse_matchers(io.StringIO(u"""filename: */trojan.rules
+        matcher = matchers.parse_matchers(io.StringIO(u"""filename: */trojan.rules
 re:.# This is a comment*
 1:100 # Trailing comment.
 """))
         self.assertEqual(
-            matchers[0].__class__, suricata.update.matchers.FilenameMatcher)
+            matcher[0].__class__, suricata.update.matchers.FilenameMatcher)
         self.assertEqual(
-            matchers[1].__class__, suricata.update.matchers.ReRuleMatcher)
+            matcher[1].__class__, suricata.update.matchers.ReRuleMatcher)
         self.assertEqual(
-            matchers[2].__class__, suricata.update.matchers.IdRuleMatcher)
+            matcher[2].__class__, suricata.update.matchers.IdRuleMatcher)
 
 class IdRuleMatcherTestCase(unittest.TestCase):
 
@@ -75,7 +76,7 @@ class IdRuleMatcherTestCase(unittest.TestCase):
         self.assertEqual(1, len(matcher.signatureIds))
 
     def test_parse_single_gidsid(self):
-        matcher = machers.IdRuleMatcher.parse("1:123")
+        matcher = matchers.IdRuleMatcher.parse("1:123")
         self.assertIsNotNone(matcher)
         self.assertEqual(1, len(matcher.signatureIds))
 

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -21,7 +21,7 @@ import io
 import unittest
 
 import suricata.update.rule
-from suricata.update import main
+from suricata.update import matchers
 import suricata.update.extract
 
 class GroupMatcherTestCase(unittest.TestCase):
@@ -30,15 +30,15 @@ class GroupMatcherTestCase(unittest.TestCase):
 
     def test_match(self):
         rule = suricata.update.rule.parse(self.rule_string, "rules/malware.rules")
-        matcher = main.parse_rule_match("group: malware.rules")
+        matcher = matchers.parse_rule_match("group: malware.rules")
         self.assertEqual(
-            matcher.__class__, suricata.update.main.GroupMatcher)
+            matcher.__class__, suricata.update.matchers.GroupMatcher)
         self.assertTrue(matcher.match(rule))
 
         # Test match of just the group basename.
-        matcher = main.parse_rule_match("group: malware")
+        matcher = matchers.parse_rule_match("group: malware")
         self.assertEqual(
-            matcher.__class__, suricata.update.main.GroupMatcher)
+            matcher.__class__, suricata.update.matchers.GroupMatcher)
         self.assertTrue(matcher.match(rule))
 
 class FilenameMatcherTestCase(unittest.TestCase):
@@ -47,62 +47,62 @@ class FilenameMatcherTestCase(unittest.TestCase):
 
     def test_match(self):
         rule = suricata.update.rule.parse(self.rule_string, "rules/trojan.rules")
-        matcher = main.parse_rule_match("filename: */trojan.rules")
+        matcher = matchers.parse_rule_match("filename: */trojan.rules")
         self.assertEqual(
-            matcher.__class__, suricata.update.main.FilenameMatcher)
+            matcher.__class__, suricata.update.matchers.FilenameMatcher)
         self.assertTrue(matcher.match(rule))
 
 class LoadMatchersTestCase(unittest.TestCase):
 
     def test_trailing_comment(self):
         """Test loading matchers with a trailing comment."""
-        matchers = main.parse_matchers(io.StringIO(u"""filename: */trojan.rules
+        matchers = matchers.parse_matchers(io.StringIO(u"""filename: */trojan.rules
 re:.# This is a comment*
 1:100 # Trailing comment.
 """))
         self.assertEqual(
-            matchers[0].__class__, suricata.update.main.FilenameMatcher)
+            matchers[0].__class__, suricata.update.matchers.FilenameMatcher)
         self.assertEqual(
-            matchers[1].__class__, suricata.update.main.ReRuleMatcher)
+            matchers[1].__class__, suricata.update.matchers.ReRuleMatcher)
         self.assertEqual(
-            matchers[2].__class__, suricata.update.main.IdRuleMatcher)
+            matchers[2].__class__, suricata.update.matchers.IdRuleMatcher)
 
 class IdRuleMatcherTestCase(unittest.TestCase):
 
     def test_parse_single_sid(self):
-        matcher = main.IdRuleMatcher.parse("123")
+        matcher = matchers.IdRuleMatcher.parse("123")
         self.assertIsNotNone(matcher)
         self.assertEqual(1, len(matcher.signatureIds))
 
     def test_parse_single_gidsid(self):
-        matcher = main.IdRuleMatcher.parse("1:123")
+        matcher = machers.IdRuleMatcher.parse("1:123")
         self.assertIsNotNone(matcher)
         self.assertEqual(1, len(matcher.signatureIds))
 
     def test_parse_multi_sid(self):
-        matcher = main.IdRuleMatcher.parse("1,2,3")
+        matcher = matchers.IdRuleMatcher.parse("1,2,3")
         self.assertIsNotNone(matcher)
         self.assertEqual(3, len(matcher.signatureIds))
 
     def test_parse_multi_gidsid(self):
-        matcher = main.IdRuleMatcher.parse("1:1000,2:2000,    3:3000, 4:4000")
+        matcher = matchers.IdRuleMatcher.parse("1:1000,2:2000,    3:3000, 4:4000")
         self.assertIsNotNone(matcher)
         self.assertEqual(4, len(matcher.signatureIds))
 
     def test_parse_multi_mixed(self):
-        matcher = main.IdRuleMatcher.parse("1:1000, 2000, 3:3000, 4000")
+        matcher = matchers.IdRuleMatcher.parse("1:1000, 2000, 3:3000, 4000")
         self.assertIsNotNone(matcher)
         self.assertEqual(4, len(matcher.signatureIds))
 
     def test_parse_invalid(self):
-        matcher = main.IdRuleMatcher.parse("a")
+        matcher = matchers.IdRuleMatcher.parse("a")
         self.assertIsNone(matcher)
 
-        matcher = main.IdRuleMatcher.parse("1, a")
+        matcher = matchers.IdRuleMatcher.parse("1, a")
         self.assertIsNone(matcher)
 
-        matcher = main.IdRuleMatcher.parse("1a")
+        matcher = matchers.IdRuleMatcher.parse("1a")
         self.assertIsNone(matcher)
 
-        matcher = main.IdRuleMatcher.parse("1:a")
+        matcher = matchers.IdRuleMatcher.parse("1:a")
         self.assertIsNone(matcher)


### PR DESCRIPTION
Since all the code for matchers happens to be in main.py thus making it quite cluttered therefore new file matchers .py has all the code for matchers for which has appropriate function calls in main.py.
Also, the files suricata-update/tests/tests_main.py and suricata-update/tests/tests_matchers.py have been modified with the references in suricata/update.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
https://redmine.openinfosecfoundation.org/issues/2873



Describe changes:
-Changed main.py , tests_main.py , tests_matchers.py
Created matchers.py
-
-
