### PR TITLE
make sure that noalert is set in newly enabled rules v2

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -725,6 +725,7 @@ def resolve_flowbits(rulemap, disabled_rules):
                     "Enabling previously disabled rule for flowbits: %s" % (
                         rule.brief()))
             rule.enabled = True
+            rule.noalert = True
             flowbit_enabled.add(rule)
     logger.info("Enabled %d rules for flowbit dependencies." % (
         len(flowbit_enabled)))

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -146,6 +146,8 @@ class Rule(dict):
         return self.format()
 
     def format(self):
+        if self.noalert and not "noalert;" in self.raw:
+            self.raw = re.sub(r'\)$', " flowbits:noalert;)", self.raw)
         return u"%s%s" % (u"" if self.enabled else u"# ", self.raw)
 
 def find_opt_end(options):


### PR DESCRIPTION
This commit adds functionality that ensures that previously
disabled rules enabled by flowbit dependencies will receive
the flowbits:noalert option.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2906

Describe changes:
- This commit adds functionality that ensures that previously disabled rules enabled by flowbit dependencies will receive the flowbits:noalert option.
- Set this to default behavior after the redmine ticket discussion.