### PR TITLE
Improve permission warning

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1286,8 +1286,13 @@ def _main():
        os.path.exists(config.get("suricata-conf")) and \
        suricata_path and os.path.exists(suricata_path):
         logger.info("Loading %s",config.get("suricata-conf"))
-        suriconf = suricata.update.engine.Configuration.load(
-            config.get("suricata-conf"), suricata_path=suricata_path)
+        try:
+            suriconf = suricata.update.engine.Configuration.load(
+                config.get("suricata-conf"), suricata_path=suricata_path)
+        except Exception as err:
+            logger.error("Permission denied: Please alter the permissions for: %s",
+                         config.get("data-directory"))
+            sys.exit(1)
 
     # Disable rule that are for app-layers that are not enabled.
     if suriconf:


### PR DESCRIPTION
Improve permission warning when Suricata-update runs with the wrong user

When `suricata-update` runs with a non-root user, it gives an ugly traceback.
To avoid those ugly tracebacks, the permission of the data-directory is
checked where the file `suricata.yaml` is loaded from and exit cleanly with
an error in the log.
The output now looks like:

```
11/4/2019 -- 01:14:42 - <Info> -- Using data-directory /usr/local/var/lib/suricata.
11/4/2019 -- 01:14:42 - <Info> -- Using Suricata configuration /usr/local/etc/suricata/suricata.yaml
11/4/2019 -- 01:14:42 - <Info> -- Using /usr/local/etc/suricata/rules for Suricata provided rules.
11/4/2019 -- 01:14:42 - <Info> -- Found Suricata version 5.0.0-dev at /usr/local/bin/suricata.
11/4/2019 -- 01:14:42 - <Info> -- Loading /usr/local/etc/suricata/suricata.yaml
11/4/2019 -- 01:14:42 - <Error> -- [ERRCODE: SC_ERR_FATAL(171)] - failed to open file: /usr/local/etc/suricata/suricata.yaml: Permission denied
11/4/2019 -- 01:14:42 - <Error> -- Permission denied: Please alter the permissions for: /usr/local/var/lib/suricata
```

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2875

Describe changes:
-
-
-
