### PR TITLE
make sure that noalert is set in newly enabled rules v5

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -725,6 +725,7 @@ def resolve_flowbits(rulemap, disabled_rules):
                     "Enabling previously disabled rule for flowbits: %s" % (
                         rule.brief()))
             rule.enabled = True
+            rule.noalert = True
             flowbit_enabled.add(rule)
     logger.info("Enabled %d rules for flowbit dependencies." % (
         len(flowbit_enabled)))

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -146,6 +146,8 @@ class Rule(dict):
         return self.format()
 
     def format(self):
+        if self.noalert and not "noalert;" in self.raw:
+            self.raw = re.sub(r'( *sid\: *[0-9]+\;)', r' noalert;\1', self.raw)
         return u"%s%s" % (u"" if self.enabled else u"# ", self.raw)
 
 def find_opt_end(options):

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -272,6 +272,8 @@ def parse(buf, group=None):
             rule.flowbits.append(val)
             if val and val.find("noalert") > -1:
                 rule["noalert"] = True
+        elif name == "noalert":
+            rule["noalert"] = True
         elif name == "reference":
             rule.references.append(val)
         elif name == "msg":

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -23,6 +23,7 @@ import io
 import tempfile
 
 import suricata.update.rule
+import suricata.update.main
 
 class RuleTestCase(unittest.TestCase):
 
@@ -123,6 +124,64 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; noalert; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)
         self.assertTrue(rule["noalert"])
+
+    def test_set_noalert(self):
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertFalse(rule["noalert"])
+        self.assertTrue(rule.enabled)
+        rule.noalert = True
+        rule.format()
+        rule1 = suricata.update.rule.parse(rule.raw)
+        self.assertTrue(rule1["noalert"])
+        self.assertEqual(rule1.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; noalert; sid:10000000; rev:1;)""")
+
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:noalert; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertTrue(rule["noalert"])
+        self.assertTrue(rule.enabled)
+        rule.format()
+        self.assertTrue(rule["noalert"])
+        self.assertEqual(rule.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:noalert; sid:10000000; rev:1;)""")
+
+    def test_resolve_flowbits(self):
+        rule_string_1 = u"""#alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:set,bit1; flowbits:noalert; sid:10000001; rev:1;)"""
+        rule_string_2 = u"""#alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit1; flowbits:set,bit2; flowbits:noalert; sid:10000002; rev:1;)"""
+        rule_string_3 = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit2; sid:10000003; rev:1;)"""
+        rule1 = suricata.update.rule.parse(rule_string_1)
+        rule2 = suricata.update.rule.parse(rule_string_2)
+        rule3 = suricata.update.rule.parse(rule_string_3)
+        rulemap = {}
+        rulemap[rule1.id] = rule1
+        rulemap[rule2.id] = rule2
+        rulemap[rule3.id] = rule3
+        disabled_rules = [rule1, rule2]
+        suricata.update.main.resolve_flowbits(rulemap, disabled_rules)
+        rule1.format()
+        rule2.format()
+        rule3.format()
+        self.assertEqual(rule1.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:set,bit1; flowbits:noalert; sid:10000001; rev:1;)""")
+        self.assertEqual(rule2.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit1; flowbits:set,bit2; flowbits:noalert; sid:10000002; rev:1;)""")
+        self.assertEqual(rule3.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit2; sid:10000003; rev:1;)""")
+
+        rule_string_1 = u"""#alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:set,bit1; sid:10000001; rev:1;)"""
+        rule_string_2 = u"""#alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit1; flowbits:set,bit2; sid:10000002; rev:1;)"""
+        rule_string_3 = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit2; sid:10000003; rev:1;)"""
+        rule1 = suricata.update.rule.parse(rule_string_1)
+        rule2 = suricata.update.rule.parse(rule_string_2)
+        rule3 = suricata.update.rule.parse(rule_string_3)
+        rulemap = {}
+        rulemap[rule1.id] = rule1
+        rulemap[rule2.id] = rule2
+        rulemap[rule3.id] = rule3
+        disabled_rules = [rule1, rule2]
+        suricata.update.main.resolve_flowbits(rulemap, disabled_rules)
+        rule1.format()
+        rule2.format()
+        rule3.format()
+        self.assertEqual(rule1.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:set,bit1; noalert; sid:10000001; rev:1;)""")
+        self.assertEqual(rule2.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit1; flowbits:set,bit2; noalert; sid:10000002; rev:1;)""")
+        self.assertEqual(rule3.raw, """alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; flowbits:isset,bit2; sid:10000003; rev:1;)""")
 
     def test_parse_message_with_semicolon(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST RULE\; and some"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -120,6 +120,10 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule = suricata.update.rule.parse(rule_string)
         self.assertTrue(rule["noalert"])
 
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; noalert; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertTrue(rule["noalert"])
+
     def test_parse_message_with_semicolon(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST RULE\; and some"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2906

Describe changes:
- adds functionality that ensures that previously disabled rules enabled by flowbit dependencies will receive the noalert option and set this to default behavior after the redmine ticket discussion.
- add functionality that ensures that rules only tagged with "noalert;" option and not only with "flowbits:noalert;" will get the rule.noalert value set to true while parsing.
- adds test cases for those two changes
- follow up to https://github.com/OISF/suricata-update/pull/142
