### PR TITLE
Parse rule files alphabetically

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1320,7 +1320,7 @@ def _main():
             del(files[filename])
 
     rules = []
-    for filename in files:
+    for filename in sorted(files):
         if not filename.endswith(".rules"):
             continue
         logger.debug("Parsing %s." % (filename))


### PR DESCRIPTION
Sort the file names before parsing them.
Example:
Currently, 
```
suricata-update -v
```
generates
```
24/3/2019 -- 10:38:16 - <Debug> -- Parsing rules/emerging-chat.rules.
24/3/2019 -- 10:38:16 - <Debug> -- Parsing sslblacklist.rules.
24/3/2019 -- 10:38:16 - <Debug> -- Parsing rules/emerging-web_client.rules.
24/3/2019 -- 10:38:16 - <Debug> -- Parsing rules/botcc.portgrouped.rules.
24/3/2019 -- 10:38:16 - <Debug> -- Parsing rules/emerging-smtp.rules.
```
i.e., the rule files are not parsed in alphabetical order.

Thus, changing the parser to load these files in alphabetical order by sorting the filenames before starting to work on them fixes the issue. Now the output generated on running
```
suricata-update -v
```
is
```
24/3/2019 -- 10:34:24 - <Debug> -- Parsing rules/botcc.rules.
24/3/2019 -- 10:34:24 - <Debug> -- Parsing rules/ciarmy.rules.
24/3/2019 -- 10:34:24 - <Debug> -- Parsing rules/compromised.rules.
24/3/2019 -- 10:34:24 - <Debug> -- Parsing rules/drop.rules.
24/3/2019 -- 10:34:24 - <Debug> -- Parsing rules/dshield.rules.
24/3/2019 -- 10:34:24 - <Debug> -- Parsing rules/emerging-activex.rules.
```
Rules files are now parsed in sorted order.

Closes Redmine ticket #2892

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
[https://redmine.openinfosecfoundation.org/issues/2892](url)
Describe changes:
Updated main.py to to load rule files in alphabetical order by sorting the filenames before starting to work on them.
