### PR TITLE
make sure that noalert is set in newly enabled rules v6

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -725,6 +725,7 @@ def resolve_flowbits(rulemap, disabled_rules):
                     "Enabling previously disabled rule for flowbits: %s" % (
                         rule.brief()))
             rule.enabled = True
+            rule.noalert = True
             flowbit_enabled.add(rule)
     logger.info("Enabled %d rules for flowbit dependencies." % (
         len(flowbit_enabled)))

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -146,6 +146,8 @@ class Rule(dict):
         return self.format()
 
     def format(self):
+        if self.noalert and not "noalert;" in self.raw:
+            self.raw = re.sub(r'( *sid\: *[0-9]+\;)', r' noalert;\1', self.raw)
         return u"%s%s" % (u"" if self.enabled else u"# ", self.raw)
 
 def find_opt_end(options):

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -272,6 +272,8 @@ def parse(buf, group=None):
             rule.flowbits.append(val)
             if val and val.find("noalert") > -1:
                 rule["noalert"] = True
+        elif name == "noalert":
+            rule["noalert"] = True
         elif name == "reference":
             rule.references.append(val)
         elif name == "msg":

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -120,6 +120,10 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule = suricata.update.rule.parse(rule_string)
         self.assertTrue(rule["noalert"])
 
+        rule_string = u"""alert ip any any -> any any (content:"uid=0|28|root|29|"; classtype:bad-unknown; noalert; sid:10000000; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertTrue(rule["noalert"])
+
     def test_parse_message_with_semicolon(self):
         rule_string = u"""alert ip any any -> any any (msg:"TEST RULE\; and some"; content:"uid=0|28|root|29|"; tag:session,5,packets; classtype:bad-unknown; sid:10000000; rev:1;)"""
         rule = suricata.update.rule.parse(rule_string)


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2906

Describe changes:
- adds functionality that ensures that previously disabled rules enabled by flowbit dependencies will receive the noalert option and set this to default behavior after the redmine ticket discussion.
- add functionality that ensures that rules only tagged with "noalert;" option and not only with "flowbits:noalert;" will get the rule.noalert value set to true while parsing.
- adds test cases for those two changes
- follow up to https://github.com/OISF/suricata-update/pull/147

