### PR TITLE
Improve permission warning

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1280,6 +1280,28 @@ def _main():
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
 
+    # Check permission for configuration file.
+    if config.get("suricata-conf") and \
+       os.path.exists(config.get("suricata-conf")):
+        try:
+            file = open(config.get("suricata-conf"))
+        except IOError as err:
+            logger.error(
+                   "permission denied for: %s", config.get("suricata-conf"))
+            return
+
+    # Check permission for rule files.
+    dist_rule_path = config.get(config.DIST_RULE_DIRECTORY_KEY)
+    files = os.listdir(dist_rule_path)
+    for rulefiles in files:
+        path = os.path.join(dist_rule_path, rulefiles)
+        try:
+            with open(path, "rb") as fileobj:
+                fileobj.read()
+        except IOError as err:
+            logger.error("permission denied for: %s", dist_rule_path)
+            return
+
     # Load the Suricata configuration if we can.
     suriconf = None
     if config.get("suricata-conf") and \


### PR DESCRIPTION
Improve permission warning when Suricata-update runs with the wrong user

When suricata-update runs with a non-root user, it gives an ugly traceback.
To avoid those ugly tracebacks, the permission of the configuration file
and rule files are checked where the files are loaded from configuration
file directory and rule output directory respectively and exit cleanly
with an error in the log.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2875

Describe changes:
-
-
-
