### PR TITLE
Improve permission warning

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1280,6 +1280,28 @@ def _main():
         logger.info("Loading %s.", drop_conf_filename)
         drop_filters += load_drop_filters(drop_conf_filename)
 
+    # Check permission for configuration file.
+    if config.get("suricata-conf") and \
+       os.path.exists(config.get("suricata-conf")):
+        try:
+            with open(config.get("suricata-conf")) as fileobj:
+                pass
+        except IOError as err:
+            logger.error(
+                   "permission denied for: %s", config.get("suricata-conf"))
+            return 1
+
+    # Check permission for output rule file.
+    if os.path.exists(config.get_output_dir()):
+        output_filename = os.path.join(
+                config.get_output_dir(), DEFAULT_OUTPUT_RULE_FILENAME)
+        try:
+            with open(output_filename) as fileobj:
+                pass
+        except IOError as err:
+            logger.error("permission denied for: %s", output_filename)
+            return 1
+
     # Load the Suricata configuration if we can.
     suriconf = None
     if config.get("suricata-conf") and \


### PR DESCRIPTION
Improve permission warning when Suricata-update runs with the wrong user

When suricata-update runs with a non-root user, it gives an ugly traceback.
To avoid those ugly tracebacks, the permission of the configuration file
and rule file is checked where the files are loaded from configuration
file directory and rule output directory respectively and exit cleanly
with an error in the log.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2875

Describe changes:
-
-
-
