### PR TITLE
Improve permission warning

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -353,6 +353,11 @@ class Fetch:
         net_arg = url
         url = url[0] if isinstance(url, tuple) else url
         tmp_filename = self.get_tmp_filename(url)
+        try:
+            with open(tmp_filename, 'wb') as fileobj:
+                pass
+        except IOError as err:
+            logger.warning("Failed to open %s: %s" % (tmp_filename, err))
         if not config.args().force and os.path.exists(tmp_filename):
             if not config.args().now and \
                time.time() - os.stat(tmp_filename).st_mtime < (60 * 15):
@@ -381,6 +386,9 @@ class Fetch:
                     "will use latest cached version: %s", url, err)
                 return self.extract_files(tmp_filename)
             raise err
+        except IOError as err:
+            logger.error("Failed to copy file %s", err)
+            sys.exit(1)
         except Exception as err:
             raise err
         self.progress_hook_finish()


### PR DESCRIPTION
Improve permission warning when Suricata-update runs with the wrong user

When suricata-update runs with a non-root user, it gives an ugly traceback.
To avoid those ugly tracebacks, the permission of the file is checked earlier
and try except block is put around the operations that are being performed on
the file and exit cleanly with an error in the log.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:https://redmine.openinfosecfoundation.org/issues/2875

Describe changes:
-
-
-
