### PR TITLE
Improve permission warnings

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -381,6 +381,10 @@ class Fetch:
                     "will use latest cached version: %s", url, err)
                 return self.extract_files(tmp_filename)
             raise err
+        except IOError as err:
+            logger.error("Failed to copy file from %s to %s",
+                         tmp_fileobj.name, tmp_filename)
+            sys.exit(1)
         except Exception as err:
             raise err
         self.progress_hook_finish()
@@ -1286,8 +1290,13 @@ def _main():
        os.path.exists(config.get("suricata-conf")) and \
        suricata_path and os.path.exists(suricata_path):
         logger.info("Loading %s",config.get("suricata-conf"))
-        suriconf = suricata.update.engine.Configuration.load(
-            config.get("suricata-conf"), suricata_path=suricata_path)
+        try:
+            suriconf = suricata.update.engine.Configuration.load(
+                config.get("suricata-conf"), suricata_path=suricata_path)
+        except subprocess.CalledProcessError as err:
+            logger.error("Permission denied. Please alter the permissions for: %s",
+                         config.get("suricata-conf"))
+            return 1
 
     # Disable rule that are for app-layers that are not enabled.
     if suriconf:


### PR DESCRIPTION
Improve permission warning when Suricata-update runs with the wrong user

When suricata-update runs with a non-root user, it gives an ugly traceback.
To avoid those ugly tracebacks, try except block is put around the operation
that are being performed on the file i.e. `shutil.copyfile(src, dest)` and
exit cleanly with an error in the log.
Also, to avoid ugly tracebacks for permission of `suricata.yaml`, try-except
is put around where it is accessed and exit cleanly with an error in the log.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:https://redmine.openinfosecfoundation.org/issues/2875

Describe changes:

If someone gets `suricata.yaml` error, the output looks like : 
```
23/5/2019 -- 02:55:44 - <Info> -- Using data-directory /usr/local/var/lib/suricata.
23/5/2019 -- 02:55:44 - <Info> -- Using Suricata configuration /usr/local/etc/suricata/suricata.yaml
23/5/2019 -- 02:55:44 - <Info> -- Using /usr/local/etc/suricata/rules for Suricata provided rules.
23/5/2019 -- 02:55:44 - <Info> -- Found Suricata version 5.0.0-dev at /usr/local/bin/suricata.
23/5/2019 -- 02:55:44 - <Info> -- Loading /usr/local/etc/suricata/suricata.yaml
23/5/2019 -- 02:55:44 - <Error> -- [ERRCODE: SC_ERR_FATAL(171)] - failed to open file: /usr/local/etc/suricata/suricata.yaml: Permission denied
23/5/2019 -- 02:55:44 - <Error> -- Permission denied. Please alter the permissions for: /usr/local/etc/suricata/suricata.yaml
```
If someone runs suricata-update with a non-root user, the output looks like :
```
23/5/2019 -- 02:26:54 - <Error> -- Failed to copy file from /tmp/tmp8yIHcb to /var/tmp/1168f1cf2d4676c8d507bbb6ea3b2078-emerging.rules.tar.gz
```