### PR TITLE
Log a warning on duplicate SID

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -692,7 +692,14 @@ def build_rule_map(rules):
         if rule.id not in rulemap:
             rulemap[rule.id] = rule
         else:
+            if rule["rev"] == rulemap[rule.id]["rev"]:
+                logger.warning(
+                    "Found duplicate rule ID {}, keeping existing rule."
+                    .format(rule.id))
             if rule["rev"] > rulemap[rule.id]["rev"]:
+                logger.warning(
+                    "Found duplicate rule ID {}, keeping one with higher revision."
+                    .format(rule.id))
                 rulemap[rule.id] = rule
 
     return rulemap


### PR DESCRIPTION
Currently when suricata-update encounters rules with duplicate SIDs,
it silently uses the one with the higher revision without logging the
warnings.
On duplicate SID, warnings are logged for equal as well as different
revisions.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2879