### PR TITLE
Separate out matchers

### DIFF
--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -1,0 +1,271 @@
+# Copyright (C) 2017 Open Information Security Foundation
+# Copyright (c) 2015-2017 Jason Ish
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+# This module contains functions for matching rules for disabling,
+# enabling, converting to drop or modification.
+
+import re
+import os.path
+import logging
+import shlex
+import fnmatch
+import suricata.update.rule
+
+
+logger = logging.getLogger()
+
+
+class AllRuleMatcher(object):
+    """Matcher object to match all rules. """
+
+    def match(self, rule):
+        return True
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.strip() == "*":
+            return cls()
+        return None
+
+
+class ProtoRuleMatcher:
+    """A rule matcher that matches on the protocol of a rule."""
+
+    def __init__(self, proto):
+        self.proto = proto
+
+    def match(self, rule):
+        return rule.proto == self.proto
+
+
+class IdRuleMatcher(object):
+    """Matcher object to match an idstools rule object by its signature
+    ID."""
+
+    def __init__(self, generatorId=None, signatureId=None):
+        self.signatureIds = []
+        if generatorId and signatureId:
+            self.signatureIds.append((generatorId, signatureId))
+
+    def match(self, rule):
+        for (generatorId, signatureId) in self.signatureIds:
+            if generatorId == rule.gid and signatureId == rule.sid:
+                return True
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        matcher = cls()
+
+        for entry in buf.split(","):
+            entry = entry.strip()
+
+            parts = entry.split(":", 1)
+            if not parts:
+                return None
+            if len(parts) == 1:
+                try:
+                    signatureId = int(parts[0])
+                    matcher.signatureIds.append((1, signatureId))
+                except:
+                    return None
+            else:
+                try:
+                    generatorId = int(parts[0])
+                    signatureId = int(parts[1])
+                    matcher.signatureIds.append((generatorId, signatureId))
+                except:
+                    return None
+
+        return matcher
+
+
+class FilenameMatcher(object):
+    """Matcher object to match a rule by its filename. This is similar to
+    a group but has no specifier prefix.
+    """
+
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def match(self, rule):
+        if hasattr(rule, "group") and rule.group is not None:
+            return fnmatch.fnmatch(rule.group, self.pattern)
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.startswith("filename:"):
+            try:
+                group = buf.split(":", 1)[1]
+                return cls(group.strip())
+            except:
+                pass
+        return None
+
+
+class GroupMatcher(object):
+    """Matcher object to match an idstools rule object by its group (ie:
+    filename).
+
+    The group is just the basename of the rule file with or without
+    extension.
+
+    Examples:
+    - emerging-shellcode
+    - emerging-trojan.rules
+
+    """
+
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def match(self, rule):
+        if hasattr(rule, "group") and rule.group is not None:
+            if fnmatch.fnmatch(os.path.basename(rule.group), self.pattern):
+                return True
+            # Try matching against the rule group without the file
+            # extension.
+            if fnmatch.fnmatch(
+                    os.path.splitext(
+                        os.path.basename(rule.group))[0], self.pattern):
+                return True
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.startswith("group:"):
+            try:
+                logger.debug("Parsing group matcher: %s" % (buf))
+                group = buf.split(":", 1)[1]
+                return cls(group.strip())
+            except:
+                pass
+        if buf.endswith(".rules"):
+            return cls(buf.strip())
+        return None
+
+
+class ReRuleMatcher(object):
+    """Matcher object to match an idstools rule object by regular
+    expression."""
+
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def match(self, rule):
+        if self.pattern.search(rule.raw):
+            return True
+        return False
+
+    @classmethod
+    def parse(cls, buf):
+        if buf.startswith("re:"):
+            try:
+                logger.debug("Parsing regex matcher: %s" % (buf))
+                patternstr = buf.split(":", 1)[1].strip()
+                pattern = re.compile(patternstr, re.I)
+                return cls(pattern)
+            except:
+                pass
+        return None
+
+
+class ModifyRuleFilter(object):
+    """Filter to modify an idstools rule object.
+
+    Important note: This filter does not modify the rule inplace, but
+    instead returns a new rule object with the modification.
+    """
+
+    def __init__(self, matcher, pattern, repl):
+        self.matcher = matcher
+        self.pattern = pattern
+        self.repl = repl
+
+    def match(self, rule):
+        return self.matcher.match(rule)
+
+    def filter(self, rule):
+        modified_rule = self.pattern.sub(self.repl, rule.format())
+        parsed = suricata.update.rule.parse(modified_rule, rule.group)
+        if parsed is None:
+            logger.error("Modification of rule %s results in invalid rule: %s",
+                         rule.idstr, modified_rule)
+            return rule
+        return parsed
+
+    @classmethod
+    def parse(cls, buf):
+        tokens = shlex.split(buf)
+        if len(tokens) == 3:
+            matchstring, a, b = tokens
+        elif len(tokens) > 3 and tokens[0] == "modifysid":
+            matchstring, a, b = tokens[1], tokens[2], tokens[4]
+        else:
+            raise Exception("Bad number of arguments.")
+        matcher = parse_rule_match(matchstring)
+        if not matcher:
+            raise Exception("Bad match string: %s" % (matchstring))
+        pattern = re.compile(a)
+
+        # Convert Oinkmaster backticks to Python.
+        b = re.sub("\$\{(\d+)\}", "\\\\\\1", b)
+
+        return cls(matcher, pattern, b)
+
+
+class DropRuleFilter(object):
+    """ Filter to modify an idstools rule object to a drop rule. """
+
+    def __init__(self, matcher):
+        self.matcher = matcher
+
+    def match(self, rule):
+        if rule["noalert"]:
+            return False
+        return self.matcher.match(rule)
+
+    def filter(self, rule):
+        drop_rule = suricata.update.rule.parse(re.sub(
+            "^\w+", "drop", rule.raw))
+        drop_rule.enabled = rule.enabled
+        return drop_rule
+
+
+def parse_rule_match(match):
+    matcher = AllRuleMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = IdRuleMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = ReRuleMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = FilenameMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    matcher = GroupMatcher.parse(match)
+    if matcher:
+        return matcher
+
+    return None

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -23,6 +23,7 @@ import unittest
 import suricata.update.rule
 from suricata.update import main
 import suricata.update.extract
+from suricata.update import matchers as matchers_mod
 
 class GroupMatcherTestCase(unittest.TestCase):
 
@@ -30,15 +31,15 @@ class GroupMatcherTestCase(unittest.TestCase):
 
     def test_match(self):
         rule = suricata.update.rule.parse(self.rule_string, "rules/malware.rules")
-        matcher = main.parse_rule_match("group: malware.rules")
+        matcher = matchers_mod.parse_rule_match("group: malware.rules")
         self.assertEqual(
-            matcher.__class__, suricata.update.main.GroupMatcher)
+            matcher.__class__, matchers_mod.GroupMatcher)
         self.assertTrue(matcher.match(rule))
 
         # Test match of just the group basename.
-        matcher = main.parse_rule_match("group: malware")
+        matcher = matchers_mod.parse_rule_match("group: malware")
         self.assertEqual(
-            matcher.__class__, suricata.update.main.GroupMatcher)
+            matcher.__class__, matchers_mod.GroupMatcher)
         self.assertTrue(matcher.match(rule))
 
 class FilenameMatcherTestCase(unittest.TestCase):
@@ -47,9 +48,9 @@ class FilenameMatcherTestCase(unittest.TestCase):
 
     def test_match(self):
         rule = suricata.update.rule.parse(self.rule_string, "rules/trojan.rules")
-        matcher = main.parse_rule_match("filename: */trojan.rules")
+        matcher = matchers_mod.parse_rule_match("filename: */trojan.rules")
         self.assertEqual(
-            matcher.__class__, suricata.update.main.FilenameMatcher)
+            matcher.__class__, matchers_mod.FilenameMatcher)
         self.assertTrue(matcher.match(rule))
 
 class LoadMatchersTestCase(unittest.TestCase):
@@ -61,48 +62,48 @@ re:.# This is a comment*
 1:100 # Trailing comment.
 """))
         self.assertEqual(
-            matchers[0].__class__, suricata.update.main.FilenameMatcher)
+            matchers[0].__class__, matchers_mod.FilenameMatcher)
         self.assertEqual(
-            matchers[1].__class__, suricata.update.main.ReRuleMatcher)
+            matchers[1].__class__, matchers_mod.ReRuleMatcher)
         self.assertEqual(
-            matchers[2].__class__, suricata.update.main.IdRuleMatcher)
+            matchers[2].__class__, matchers_mod.IdRuleMatcher)
 
 class IdRuleMatcherTestCase(unittest.TestCase):
 
     def test_parse_single_sid(self):
-        matcher = main.IdRuleMatcher.parse("123")
+        matcher = matchers_mod.IdRuleMatcher.parse("123")
         self.assertIsNotNone(matcher)
         self.assertEqual(1, len(matcher.signatureIds))
 
     def test_parse_single_gidsid(self):
-        matcher = main.IdRuleMatcher.parse("1:123")
+        matcher = matchers_mod.IdRuleMatcher.parse("1:123")
         self.assertIsNotNone(matcher)
         self.assertEqual(1, len(matcher.signatureIds))
 
     def test_parse_multi_sid(self):
-        matcher = main.IdRuleMatcher.parse("1,2,3")
+        matcher = matchers_mod.IdRuleMatcher.parse("1,2,3")
         self.assertIsNotNone(matcher)
         self.assertEqual(3, len(matcher.signatureIds))
 
     def test_parse_multi_gidsid(self):
-        matcher = main.IdRuleMatcher.parse("1:1000,2:2000,    3:3000, 4:4000")
+        matcher = matchers_mod.IdRuleMatcher.parse("1:1000,2:2000,    3:3000, 4:4000")
         self.assertIsNotNone(matcher)
         self.assertEqual(4, len(matcher.signatureIds))
 
     def test_parse_multi_mixed(self):
-        matcher = main.IdRuleMatcher.parse("1:1000, 2000, 3:3000, 4000")
+        matcher = matchers_mod.IdRuleMatcher.parse("1:1000, 2000, 3:3000, 4000")
         self.assertIsNotNone(matcher)
         self.assertEqual(4, len(matcher.signatureIds))
 
     def test_parse_invalid(self):
-        matcher = main.IdRuleMatcher.parse("a")
+        matcher = matchers_mod.IdRuleMatcher.parse("a")
         self.assertIsNone(matcher)
 
-        matcher = main.IdRuleMatcher.parse("1, a")
+        matcher = matchers_mod.IdRuleMatcher.parse("1, a")
         self.assertIsNone(matcher)
 
-        matcher = main.IdRuleMatcher.parse("1a")
+        matcher = matchers_mod.IdRuleMatcher.parse("1a")
         self.assertIsNone(matcher)
 
-        matcher = main.IdRuleMatcher.parse("1:a")
+        matcher = matchers_mod.IdRuleMatcher.parse("1:a")
         self.assertIsNone(matcher)


### PR DESCRIPTION
Currently, all the code for matchers happens to be in main.py
which makes it quite cluttered. A separate `matchers.py` module
is created which contains all the code for matching rules and
integrated with main.py. Also the modules `test_main.py` and
`test_matchers.py` are modified accordingly.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [ ] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2873
