### PR TITLE
Add "offline" command

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -353,6 +353,16 @@ class Fetch:
         net_arg = url
         url = url[0] if isinstance(url, tuple) else url
         tmp_filename = self.get_tmp_filename(url)
+        if config.args().offline:
+            if config.args().force:
+                logger.warning("Failed to force remote rule file: %s to be "
+                               "downloaded.", url)
+            logger.info("Using latest cached version of rule file: %s", url)
+            if not os.path.exists(tmp_filename):
+                logger.error("Can't proceed offline, "
+                             "source %s has not yet been downloaded.", url)
+                sys.exit(1)
+            return self.extract_files(tmp_filename)
         if not config.args().force and os.path.exists(tmp_filename):
             if not config.args().now and \
                time.time() - os.stat(tmp_filename).st_mtime < (60 * 15):
@@ -985,7 +995,7 @@ def load_sources(suricata_version):
     # If --etopen is on the command line, make sure its added. Or if
     # there are no URLs, default to ET/Open.
     if config.get("etopen") or not urls:
-        if not urls:
+        if not config.args().offline and not urls:
             logger.info("No sources configured, will use Emerging Threats Open")
         urls.append(sources.get_etopen_url(internal_params))
 
@@ -1129,6 +1139,9 @@ def _main():
     
     update_parser.add_argument("--no-merge", action="store_true", default=False,
                                help="Do not merge the rules into a single file")
+    update_parser.add_argument("--offline", action="store_true",
+                               help="Proceed offline. "
+                                    "Use locally cached latest version of rules.")
 
     # Hidden argument, --now to bypass the timebased bypass of
     # updating a ruleset.


### PR DESCRIPTION
Add a command line option `--offline` that uses locally cached
latest version of rules without trying to download rules from
sources.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2864