### PR TITLE
Log a warning if index is old

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -87,6 +87,8 @@ DEFAULT_SURICATA_VERSION = "4.0.0"
 # single file concatenating all input rule files together.
 DEFAULT_OUTPUT_RULE_FILENAME = "suricata.rules"
 
+INDEX_EXPIRATION_TIME = 60 * 60 * 24 * 14
+
 class AllRuleMatcher(object):
     """Matcher object to match all rules. """
 
@@ -955,6 +957,10 @@ def load_sources(suricata_version):
         if not os.path.exists(index_filename):
             logger.warning("No index exists, will use bundled index.")
             logger.warning("Please run suricata-update update-sources.")
+        if os.path.exists(index_filename) and time.time() - \
+                os.stat(index_filename).st_mtime > INDEX_EXPIRATION_TIME:
+            logger.warning("Source index is greater than 2 weeks old. "
+                "Please update with suricata-update update-sources.")
         index = sources.Index(index_filename)
 
         for (name, source) in enabled_sources.items():


### PR DESCRIPTION
If the index is older than 2 weeks, logged a warning that the
index is old and user needs to update it by running
`suricata-update update-sources`.

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2340
