### PR TITLE
Add "check-versions" subcommand

### DIFF
--- a/suricata/update/commands/__init__.py
+++ b/suricata/update/commands/__init__.py
@@ -21,3 +21,4 @@ from suricata.update.commands import updatesources
 from suricata.update.commands import enablesource
 from suricata.update.commands import disablesource
 from suricata.update.commands import removesource
+from suricata.update.commands import checkversions

--- a/suricata/update/commands/checkversions.py
+++ b/suricata/update/commands/checkversions.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2017 Open Information Security Foundation
+#
+# You can copy, redistribute or modify this Program under the terms of
+# the GNU General Public License version 2 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# version 2 along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from __future__ import print_function
+
+import os.path
+import logging
+from suricata.update import sources
+
+logger = logging.getLogger()
+
+
+def register(parser):
+    parser.set_defaults(func=check_version)
+
+
+def check_version(suricata_version):
+    index_filename = sources.get_index_filename()
+    if not os.path.exists(index_filename):
+        logger.warning("No index exists, will use bundled index.")
+        logger.warning("Please run suricata-update update-sources.")
+    index = sources.Index(index_filename)
+    version = index.get_versions()
+    if suricata_version.full in version['suricata']['recommended'] or \
+            "dev" in suricata_version.full:
+        logger.info("Suricata version %s is up to date", suricata_version.full)
+    elif suricata_version.short in version['suricata'] and \
+            suricata_version.full not in \
+            version['suricata'][suricata_version.short]:
+        logger.warning(
+            "Suricata version %s is outdated. Please upgrade to %s.",
+            suricata_version.full, version['suricata']['recommended'])
+    else:
+        logger.warning(
+            "Suricata version %s has reached EOL. Please upgrade to %s.",
+            suricata_version.full, version['suricata']['recommended'])

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1143,6 +1143,7 @@ def _main():
     remove-source              Remove an enabled or disabled source
     list-enabled-sources       List all enabled sources
     add-source                 Add a new source by URL
+    check-versions             Check version of suricata
 """
 
     # The Python 2.7 argparse module does prefix matching which can be
@@ -1170,6 +1171,8 @@ def _main():
         "disable-source", parents=[global_parser]))
     commands.removesource.register(subparsers.add_parser(
         "remove-source", parents=[global_parser]))
+    commands.checkversions.register(subparsers.add_parser(
+        "check-versions", parents=[global_parser]))
 
     args = parser.parse_args(rem)
 
@@ -1235,7 +1238,9 @@ def _main():
     suricata.update.net.set_user_agent_suricata_version(suricata_version.full)
 
     if args.subcommand:
-        if hasattr(args, "func"):
+        if args.subcommand == "check-versions" and hasattr(args, "func"):
+            return args.func(suricata_version)
+        elif hasattr(args, "func"):
             return args.func()
         elif args.subcommand != "update":
             logger.error("Unknown command: %s", args.subcommand)

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -126,6 +126,12 @@ class Index:
             return self.index["sources"][name]
         return None
 
+    def get_versions(self):
+        try:
+            return self.index["versions"]
+        except KeyError:
+            raise Exception("Version information not in index")
+
 def load_source_index(config):
     return Index(get_index_filename())
 


### PR DESCRIPTION
Add a `suricata-update check-versions` subcommand that checks
the version of suricata and logs if the versions are up to date, 
outdated or EOL.

**Sample**

```
└─ $ ▶ ./bin/suricata-update check-versions
22/7/2019 -- 10:40:46 - <Info> -- Using data-directory /usr/local/var/lib/suricata.
22/7/2019 -- 10:40:46 - <Info> -- Using Suricata configuration /usr/local/etc/suricata/suricata.yaml
22/7/2019 -- 10:40:46 - <Info> -- Using /usr/local/etc/suricata/rules for Suricata provided rules.
22/7/2019 -- 10:40:46 - <Info> -- Found Suricata version 5.0.0-dev at /usr/local/bin/suricata.
22/7/2019 -- 10:40:46 - <Info> -- Suricata version 5.0.0-dev is up to date
```

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2341