### PR TITLE
Add no-checksum option

### DIFF
--- a/doc/add-source.rst
+++ b/doc/add-source.rst
@@ -25,6 +25,10 @@ Options
 
      add-source --http-header "X-API-Key: 1234"
 
+.. option:: --no-checksum
+
+   Skips downloading the checksum URL for the rule source.
+
 Common Options
 ==============
 

--- a/suricata/update/commands/addsource.py
+++ b/suricata/update/commands/addsource.py
@@ -28,13 +28,17 @@ except:
 
 logger = logging.getLogger()
 
+
 def register(parser):
     parser.add_argument("name", metavar="<name>", nargs="?",
                         help="Name of source")
     parser.add_argument("url", metavar="<url>", nargs="?", help="Source URL")
     parser.add_argument("--http-header", metavar="<http-header>",
                         help="Additional HTTP header to add to requests")
+    parser.add_argument("--no-checksum", action="store_true",
+                        help="Skips downloading the checksum URL")
     parser.set_defaults(func=add_source)
+
 
 def add_source():
     args = config.args()
@@ -59,7 +63,10 @@ def add_source():
             if url:
                 break
 
+    no_checksum = args.no_checksum
+
     header = args.http_header if args.http_header else None
 
-    source_config = sources.SourceConfiguration(name, header=header, url=url)
+    source_config = sources.SourceConfiguration(
+        name, header=header, url=url, no_checksum=no_checksum)
     sources.save_source_config(source_config)

--- a/suricata/update/commands/enablesource.py
+++ b/suricata/update/commands/enablesource.py
@@ -103,7 +103,13 @@ def enable_source():
                         break
                 params[param] = r.strip()
 
-    new_source = sources.SourceConfiguration(name, params=params)
+    if "no-checksum" in source:
+        no_checksum = source["no-checksum"]
+    else:
+        no_checksum = source.get("no-checksum", False)
+
+    new_source = sources.SourceConfiguration(
+        name, params=params, no_checksum=no_checksum)
 
     # If the source directory does not exist, create it. Also create
     # the default rule-source of et/open, unless the source being

--- a/suricata/update/sources.py
+++ b/suricata/update/sources.py
@@ -77,11 +77,13 @@ def save_source_config(source_config):
 
 class SourceConfiguration:
 
-    def __init__(self, name, header=None, url=None, params={}):
+    def __init__(self, name, header=None, url=None,
+                 params={}, no_checksum=False):
         self.name = name
         self.url = url
         self.params = params
         self.header = header
+        self.no_checksum = no_checksum
 
     def dict(self):
         d = {
@@ -93,6 +95,8 @@ class SourceConfiguration:
             d["params"] = self.params
         if self.header:
             d["http-header"] = self.header
+        if self.no_checksum:
+            d["no-checksum"] = self.no_checksum
         return d
 
 class Index:


### PR DESCRIPTION
Added a `--no-checksum` option to the add-source command and an optional
"no_checksum" in SourceConfiguration class for add-sources and
enabled-sources.
Also, a check is added to skip downloading the checksum URL if the
source is configured with no-checksum true.

Redmine issue:
    https://redmine.openinfosecfoundation.org/issues/3100

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3100