### PR TITLE
Disable ja3_hash rules as needed - v1

### DIFF
--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -208,9 +208,15 @@ def init(args):
                 0, os.path.join(
                     build_info["sysconfdir"], "suricata/suricata.yaml"))
 
+        # Amend the path to look for Suricata provided rules based on
+        # the build info. As we are inserting at the front, put the
+        # highest priority path last.
         if "sysconfdir" in build_info:
             DEFAULT_DIST_RULE_PATH.insert(
                 0, os.path.join(build_info["sysconfdir"], "suricata/rules"))
+        if "datarootdir" in build_info:
+            DEFAULT_DIST_RULE_PATH.insert(
+                0, os.path.join(build_info["datarootdir"], "suricata/rules"))
 
         # Set the data-directory prefix to that of the --localstatedir
         # found in the build-info.

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -49,6 +49,8 @@ def get_build_info(suricata):
             build_info["localstatedir"] = line.split()[-1].strip()
         elif line.startswith("Features:"):
             build_info["features"] = line.split()[1:]
+        elif line.startswith("This is Suricata version"):
+            build_info["version"] = parse_version(line)
 
     if not "prefix" in build_info:
         logger.warning("--prefix not found in build-info.")

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -107,7 +107,8 @@ class Configuration:
                 conf[key] = val
             except:
                 logger.warning("Failed to parse: %s", line)
-        return cls(conf)
+        build_info = get_build_info(suricata_path)
+        return cls(conf, build_info)
 
 def get_path(program="suricata"):
     """Find Suricata in the shell path."""

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -35,7 +35,9 @@ SuricataVersion = namedtuple(
     "SuricataVersion", ["major", "minor", "patch", "full", "short", "raw"])
 
 def get_build_info(suricata):
-    build_info = {}
+    build_info = {
+        "features": [],
+    }
     build_info_output = subprocess.check_output([suricata, "--build-info"])
     for line in build_info_output.decode("utf-8").split("\n"):
         line = line.strip()
@@ -45,6 +47,8 @@ def get_build_info(suricata):
             build_info["sysconfdir"] = line.split()[-1].strip()
         elif line.startswith("--localstatedir"):
             build_info["localstatedir"] = line.split()[-1].strip()
+        elif line.startswith("Features:"):
+            build_info["features"] = line.split()[1:]
 
     if not "prefix" in build_info:
         logger.warning("--prefix not found in build-info.")

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -47,6 +47,8 @@ def get_build_info(suricata):
             build_info["sysconfdir"] = line.split()[-1].strip()
         elif line.startswith("--localstatedir"):
             build_info["localstatedir"] = line.split()[-1].strip()
+        elif line.startswith("--datarootdir"):
+            build_info["datarootdir"] = line.split()[-1].strip()
         elif line.startswith("Features:"):
             build_info["features"] = line.split()[1:]
         elif line.startswith("This is Suricata version"):

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -64,14 +64,18 @@ def get_build_info(suricata):
 class Configuration:
     """An abstraction over the Suricata configuration file."""
 
-    def __init__(self, conf):
+    def __init__(self, conf, build_info = {}):
         self.conf = conf
+        self.build_info = build_info
 
     def keys(self):
         return self.conf.keys()
 
     def has_key(self, key):
         return key in self.conf
+
+    def get(self, key):
+        return self.conf.get(key, None)
 
     def is_true(self, key, truthy=[]):
         if not key in self.conf:

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -76,6 +76,7 @@ class Rule(dict):
     - **classtype**: The classification type
     - **priority**: The rule priority, 0 if not provided
     - **noalert**: Is the rule a noalert rule
+    - **features**: Features required by this rule
     - **raw**: The raw rule as read from the file or buffer
 
     :param enabled: Optional parameter to set the enabled state of the rule
@@ -105,6 +106,8 @@ class Rule(dict):
         self["classtype"] = None
         self["priority"] = 0
         self["noalert"] = False
+
+        self["features"] = []
 
         self["raw"] = None
 
@@ -285,6 +288,9 @@ def parse(buf, group=None):
             rule[name] = val
         else:
             rule[name] = val
+
+        if name == "ja3_hash":
+            rule["features"].append("ja3")
 
     if rule["msg"] is None:
         rule["msg"] = ""


### PR DESCRIPTION
Disable ja3_hash rules if Suricata not configured for ja3.

Rules using ja3_hash with fail to load if Suricata is not built with NSS,
or ja3 fingerprints are disabled.

Take into account the Suricata version as well, as not defining the
ja3_fingerprint configuration field in 5.0+ will leave it enabled, but in
older versions, it will remain disabled if not defined.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3215