### PR TITLE
Disable ja3 rules as needed - v2

### DIFF
--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -208,9 +208,15 @@ def init(args):
                 0, os.path.join(
                     build_info["sysconfdir"], "suricata/suricata.yaml"))
 
+        # Amend the path to look for Suricata provided rules based on
+        # the build info. As we are inserting at the front, put the
+        # highest priority path last.
         if "sysconfdir" in build_info:
             DEFAULT_DIST_RULE_PATH.insert(
                 0, os.path.join(build_info["sysconfdir"], "suricata/rules"))
+        if "datarootdir" in build_info:
+            DEFAULT_DIST_RULE_PATH.insert(
+                0, os.path.join(build_info["datarootdir"], "suricata/rules"))
 
         # Set the data-directory prefix to that of the --localstatedir
         # found in the build-info.

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -49,6 +49,8 @@ def get_build_info(suricata):
             build_info["localstatedir"] = line.split()[-1].strip()
         elif line.startswith("Features:"):
             build_info["features"] = line.split()[1:]
+        elif line.startswith("This is Suricata version"):
+            build_info["version"] = parse_version(line)
 
     if not "prefix" in build_info:
         logger.warning("--prefix not found in build-info.")

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -107,7 +107,8 @@ class Configuration:
                 conf[key] = val
             except:
                 logger.warning("Failed to parse: %s", line)
-        return cls(conf)
+        build_info = get_build_info(suricata_path)
+        return cls(conf, build_info)
 
 def get_path(program="suricata"):
     """Find Suricata in the shell path."""

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -35,7 +35,9 @@ SuricataVersion = namedtuple(
     "SuricataVersion", ["major", "minor", "patch", "full", "short", "raw"])
 
 def get_build_info(suricata):
-    build_info = {}
+    build_info = {
+        "features": [],
+    }
     build_info_output = subprocess.check_output([suricata, "--build-info"])
     for line in build_info_output.decode("utf-8").split("\n"):
         line = line.strip()
@@ -45,6 +47,8 @@ def get_build_info(suricata):
             build_info["sysconfdir"] = line.split()[-1].strip()
         elif line.startswith("--localstatedir"):
             build_info["localstatedir"] = line.split()[-1].strip()
+        elif line.startswith("Features:"):
+            build_info["features"] = line.split()[1:]
 
     if not "prefix" in build_info:
         logger.warning("--prefix not found in build-info.")

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -47,6 +47,8 @@ def get_build_info(suricata):
             build_info["sysconfdir"] = line.split()[-1].strip()
         elif line.startswith("--localstatedir"):
             build_info["localstatedir"] = line.split()[-1].strip()
+        elif line.startswith("--datarootdir"):
+            build_info["datarootdir"] = line.split()[-1].strip()
         elif line.startswith("Features:"):
             build_info["features"] = line.split()[1:]
         elif line.startswith("This is Suricata version"):

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -64,14 +64,18 @@ def get_build_info(suricata):
 class Configuration:
     """An abstraction over the Suricata configuration file."""
 
-    def __init__(self, conf):
+    def __init__(self, conf, build_info = {}):
         self.conf = conf
+        self.build_info = build_info
 
     def keys(self):
         return self.conf.keys()
 
     def has_key(self, key):
         return key in self.conf
+
+    def get(self, key):
+        return self.conf.get(key, None)
 
     def is_true(self, key, truthy=[]):
         if not key in self.conf:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1062,6 +1062,49 @@ def check_output_directory(output_dir):
                 "Failed to create directory %s: %s" % (
                     output_dir, err))
 
+# Check and disable ja3 rules if needed.
+#
+# Note: This is a bit of a quick fixup job for 5.0, but we should look
+# at making feature handling more generic.
+def disable_ja3(suriconf, rulemap, disabled_rules):
+    if suriconf and suriconf.build_info:
+        enabled = False
+        reason = None
+        logged = False
+        if "HAVE_NSS" not in suriconf.build_info["features"]:
+            reason = "Disabling rules with ja3_hash as Suricata built without libnss."
+        else:
+            # Check if disabled. Must be explicitly disabled,
+            # otherwise we'll keep ja3 rules enabled.
+            val = suriconf.get("app-layer.protocols.tls.ja3-fingerprints")
+
+            # Prior to Suricata 5, leaving ja3-fingerprints undefined
+            # in the configuration disabled the feature. With 5.0,
+            # having it undefined will enable it as needed.
+            if not val:
+                if suriconf.build_info["version"].major < 5:
+                    val = "no"
+                else:
+                    val = "auto"
+
+            if val and val.lower() not in ["1", "yes", "true", "auto"]:
+                reason = "Disabling rules with ja3_hash as ja3 fingerprints are not enabled."
+            else:
+                enabled = True
+
+        count = 0
+        if not enabled:
+            for key, rule in rulemap.items():
+                if "ja3" in rule["features"]:
+                    if not logged:
+                        logger.warn(reason)
+                        logged = True
+                    rule.enabled = False
+                    disabled_rules.append(rule)
+                    count += 1
+            if count:
+                logger.info("%d ja3_hash rules disabled." % (count))
+
 def _main():
     global args
 
@@ -1415,6 +1458,12 @@ def _main():
                 if new_rule and new_rule.format() != rule.format():
                     rulemap[rule.id] = new_rule
                     modify_count += 1
+
+    # Check if we should disable ja3 rules.
+    try:
+        disable_ja3(suriconf, rulemap, disabled_rules)
+    except Exception as err:
+        logger.error("Failed to dynamically disable ja3 rules: %s" % (err))
 
     # Check rule vars, disabling rules that use unknown vars.
     check_vars(suriconf, rulemap)

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 Open Information Security Foundation
+# Copyright (C) 2017-2019 Open Information Security Foundation
 # Copyright (c) 2011 Jason Ish
 #
 # You can copy, redistribute or modify this Program under the terms of
@@ -76,6 +76,7 @@ class Rule(dict):
     - **classtype**: The classification type
     - **priority**: The rule priority, 0 if not provided
     - **noalert**: Is the rule a noalert rule
+    - **features**: Features required by this rule
     - **raw**: The raw rule as read from the file or buffer
 
     :param enabled: Optional parameter to set the enabled state of the rule
@@ -105,6 +106,8 @@ class Rule(dict):
         self["classtype"] = None
         self["priority"] = 0
         self["noalert"] = False
+
+        self["features"] = []
 
         self["raw"] = None
 
@@ -285,6 +288,9 @@ def parse(buf, group=None):
             rule[name] = val
         else:
             rule[name] = val
+
+        if name.startswith("ja3"):
+            rule["features"].append("ja3")
 
     if rule["msg"] is None:
         rule["msg"] = ""

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -242,3 +242,15 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         self.assertRaises(
             suricata.update.rule.BadSidError,
             suricata.update.rule.parse, rule_buf)
+
+    def test_parse_feature_ja3(self):
+        """Test parsing rules that should set the ja3 feature."""
+        rule_string = u"""alert tls any any -> any any (msg:"REQUIRES JA3"; ja3_hash; content:"61d50e7771aee7f2f4b89a7200b4d45"; sid:1; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertIsNotNone(rule)
+        self.assertTrue("ja3" in rule["features"])
+
+        rule_string = u"""alert tls any any -> any any (msg:"REQUIRES JA3"; ja3.hash; content:"61d50e7771aee7f2f4b89a7200b4d45"; sid:1; rev:1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertIsNotNone(rule)
+        self.assertTrue("ja3" in rule["features"])


### PR DESCRIPTION
Previous PR:
https://github.com/OISF/suricata-update/pull/197

Changes from last PR:
- Refactor to put ja3 disabling code in method wrapped
  in try/except to be more robust against unforeseen
  errors.
- Add a unit test to check that the ja3 feature is
  set for a ja3 using rule.
- Check for keywords that start with "ja3".

Link
to
[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3215