### PR TITLE
Support for rule filtering based on metadata key-value pairs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,7 @@ Make sure these boxes are signed before submitting your Pull Request
 - [ ] I have updated the user guide (in doc/userguide/) to reflect the
   changes made (if applicable)
 
-Link
-to
-[redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
+Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
 
 Describe changes:
 -

--- a/doc/update.rst
+++ b/doc/update.rst
@@ -251,6 +251,12 @@ desired outcome based on Boolean logic, where the metadata
 key-value pairs are values in a (concrete) Boolean algebra. For
 details see `<https://aristotle-py.readthedocs.io/en/latest/filter_strings.html>`__
 
+   .. note::
+
+     Metadata filtering happens `after` the ``--ignore`` (filename)
+     directive is processed but `before` other rule matching
+     directives are applied.
+
 Modifying Rules
 ---------------
 

--- a/doc/update.rst
+++ b/doc/update.rst
@@ -186,6 +186,7 @@ modification can be done with the following:
 - regular expression
 - rule group
 - filename
+- metadata filter
 
 Signature ID Matching
 ---------------------
@@ -232,6 +233,24 @@ are allowed::
   filename:rules/*deleted*
   filename:*/emerging-dos.rules
 
+Metadata Filtering
+------------------
+
+Rules can be enabled and disabled based on metadata key-value pairs
+present in the Suricata rule ``metadata`` keyword.
+
+   .. note::
+
+     Filtering based on metadata requires
+     a ruleset that is compatible with the
+     `BETTER Schema <https://better-schema.readthedocs.io/>`__
+
+Metadata filtering is applied by
+supplying a file containing a "filter string" which defines the
+desired outcome based on Boolean logic, where the metadata
+key-value pairs are values in a (concrete) Boolean algebra. For
+details see `<https://aristotle-py.readthedocs.io/en/latest/filter_strings.html>`__
+
 Modifying Rules
 ---------------
 
@@ -276,6 +295,11 @@ Example Configuration to Disable Rules (--disable-conf)
 .. literalinclude:: ../suricata/update/configs/disable.conf
 
 .. _example-drop-conf:
+
+Example Configuration Containing Metadata Filter String (--metatdata-conf)
+--------------------------------------------------------------------------
+
+See `<https://github.com/secureworks/aristotle/tree/master/examples>`__.
 
 Example Configuration to convert Rules to Drop (--drop-conf)
 ------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinxcontrib-programoutput
 Sphinx
 python-dateutil
 PyYAML
+aristotle

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -27,7 +27,6 @@ import time
 import hashlib
 import fnmatch
 import subprocess
-import types
 import shutil
 import glob
 import io
@@ -1018,7 +1017,7 @@ def load_sources(suricata_version):
 
     if config.get("sources"):
         for url in config.get("sources"):
-            if type(url) not in [type("")]:
+            if not isinstance(url, str):
                 raise exceptions.InvalidConfigurationError(
                     "Invalid datatype for source URL: %s" % (str(url)))
             url = (url % internal_params, http_header, checksum)

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -313,7 +313,10 @@ def parse_fileobj(fileobj, group=None):
     """
     rules = []
     buf = ""
+    better_metadata = False
     for line in fileobj:
+        if line.startswith("#better-schema "):
+            better_metadata = True
         try:
             if type(line) == type(b""):
                 line = line.decode()
@@ -326,6 +329,8 @@ def parse_fileobj(fileobj, group=None):
         try:
             rule = parse(buf, group)
             if rule:
+                if better_metadata:
+                    rule["features"].append("better-metadata")
                 rules.append(rule)
         except Exception as err:
             logger.error("Failed to parse rule: %s: %s", buf.rstrip(), err)

--- a/suricata/update/version.py
+++ b/suricata/update/version.py
@@ -4,4 +4,4 @@
 # Alpha: 1.0.0a1
 # Development: 1.0.0dev0
 # Release candidate: 1.0.0rc1
-version = "1.1.0"
+version = "1.2.0dev0"


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [X] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Added support for filtering rulesets based on metadata key-value pairs, using Boolean filters.
- Leverages BETTER Schema standard (https://better-schema.readthedocs.io/).
- Uses the Aristotle library (https://github.com/secureworks/aristotle/, https://pypi.org/project/aristotle/).
