### PR TITLE
Support for rule filtering based on metadata key-value pairs

### DIFF
--- a/doc/update.rst
+++ b/doc/update.rst
@@ -186,6 +186,7 @@ modification can be done with the following:
 - regular expression
 - rule group
 - filename
+- metadata filter
 
 Signature ID Matching
 ---------------------
@@ -232,6 +233,30 @@ are allowed::
   filename:rules/*deleted*
   filename:*/emerging-dos.rules
 
+Metadata Filtering
+------------------
+
+Rules can be enabled and disabled based on metadata key-value pairs
+present in the Suricata rule ``metadata`` keyword.
+
+   .. note::
+
+     Filtering based on metadata requires
+     a ruleset that is compatible with the
+     `BETTER Schema <https://better-schema.readthedocs.io/>`__
+
+Metadata filtering is applied by
+supplying a file containing a "filter string" which defines the
+desired outcome based on Boolean logic, where the metadata
+key-value pairs are values in a (concrete) Boolean algebra. For
+details see `<https://aristotle-py.readthedocs.io/en/latest/filter_strings.html>`__
+
+   .. note::
+
+     Metadata filtering happens `after` the ``--ignore`` (filename)
+     directive is processed but `before` other rule matching
+     directives are applied.
+
 Modifying Rules
 ---------------
 
@@ -276,6 +301,11 @@ Example Configuration to Disable Rules (--disable-conf)
 .. literalinclude:: ../suricata/update/configs/disable.conf
 
 .. _example-drop-conf:
+
+Example Configuration Containing Metadata Filter String (--metatdata-conf)
+--------------------------------------------------------------------------
+
+See `<https://github.com/secureworks/aristotle/tree/master/examples>`__.
 
 Example Configuration to convert Rules to Drop (--drop-conf)
 ------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinxcontrib-programoutput
 Sphinx
 python-dateutil
 PyYAML
+aristotle>=1.0.3

--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -47,6 +47,7 @@ DISABLE_CONF_KEY = "disable-conf"
 ENABLE_CONF_KEY = "enable-conf"
 MODIFY_CONF_KEY = "modify-conf"
 DROP_CONF_KEY = "drop-conf"
+METADATA_CONF_KEY = "metadata-conf"
 LOCAL_CONF_KEY = "local"
 OUTPUT_KEY = "output"
 DIST_RULE_DIRECTORY_KEY = "dist-rule-directory"
@@ -77,6 +78,7 @@ DEFAULT_CONFIG = {
     "enable-conf": "/etc/suricata/enable.conf",
     "drop-conf": "/etc/suricata/drop.conf",
     "modify-conf": "/etc/suricata/modify.conf",
+    "metadata-conf": "/etc/suricata/metadata.conf",
     "sources": [],
     LOCAL_CONF_KEY: [],
 

--- a/suricata/update/configs/metadata.conf
+++ b/suricata/update/configs/metadata.conf
@@ -1,0 +1,17 @@
+# suricata-update - metadata.conf
+
+# Format: Boolean filter string
+
+#########################################################################
+# See https://aristotle-py.readthedocs.io/en/latest/filter_strings.html #
+#########################################################################
+
+# Example - match all high priority malware related rules:
+#"priority high" AND "malware <ALL>"
+
+#Example - match all high priority malware related rules that were created in 2018 or later:
+#("priority high" AND "malware <ALL>") AND "created_at > 2018-01-01"
+
+#Example - match all high and medium rules that are designed to protect a webserver:
+#("priority high" OR "priority medium") AND ("attack_target http-server" OR "attack_target tls-server")
+

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -313,12 +313,15 @@ def parse_fileobj(fileobj, group=None):
     """
     rules = []
     buf = ""
+    better_metadata = False
     for line in fileobj:
         try:
             if type(line) == type(b""):
                 line = line.decode()
         except:
             pass
+        if line.startswith("#better-schema "):
+            better_metadata = True
         if line.rstrip().endswith("\\"):
             buf = "%s%s " % (buf, line.rstrip()[0:-1])
             continue
@@ -326,6 +329,8 @@ def parse_fileobj(fileobj, group=None):
         try:
             rule = parse(buf, group)
             if rule:
+                if better_metadata:
+                    rule["features"].append("better-metadata")
                 rules.append(rule)
         except Exception as err:
             logger.error("Failed to parse rule: %s: %s", buf.rstrip(), err)


### PR DESCRIPTION
- [X] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Rule Matching: Rules can be enabled and disabled based on metadata key-value pairs
present in the Suricata rule metadata keyword.

    - Added Rule Matching support for filtering rulesets based on metadata key-value pairs,
      using Boolean filters.

    - New conf file, 'metadata.conf' (functionally empty by default); passing conf file on
      command line also supported.

    - Leverages BETTER Schema standard (https://better-schema.readthedocs.io/).

    - Added requirement, 'aristotle'; code additions leverage use the Aristotle library
      (https://github.com/secureworks/aristotle/, https://pypi.org/project/aristotle/).

    - Updated docs to include new feature(s).
