### PR TITLE
Ticket 3174 - Handle duplicate filenames - v1

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -407,7 +407,7 @@ class Fetch:
         logger.info("Done.")
         return self.extract_files(tmp_filename)
 
-    def run(self, url=None, files=None):
+    def run(self, url, files=None):
         if files is None:
             files = {}
         if url:
@@ -417,9 +417,6 @@ class Fetch:
             except URLError as err:
                 url = url[0] if isinstance(url, tuple) else url
                 logger.error("Failed to fetch %s: %s", url, err)
-        else:
-            for url in self.args.url:
-                files.update(self.fetch(url))
         return files
 
     def extract_files(self, filename):

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -413,7 +413,8 @@ class Fetch:
         if url:
             try:
                 fetched = self.fetch(url)
-                files.update(fetched)
+                for key in fetched:
+                    files["{}!{}".format(url[0], key)] = fetched[key]
             except URLError as err:
                 url = url[0] if isinstance(url, tuple) else url
                 logger.error("Failed to fetch %s: %s", url, err)


### PR DESCRIPTION
    Handle duplicate filenames across sources.
    
    In the dict that holds the downloaded files, prefix the filename
    with the URL using '!' as a separator.
    
    Ticket 3174:
    https://redmine.openinfosecfoundation.org/issues/3174
