### PR TITLE
move modify into loop with others and skip format check

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1063,12 +1063,10 @@ def _main():
                 rulemap[rule.id] = fltr.run(rule)
                 drop_count += 1
 
-    # Apply modify filters.
-    for fltr in modify_filters:
-        for key, rule in rulemap.items():
+        for fltr in modify_filters:
             if fltr.match(rule):
                 new_rule = fltr.run(rule)
-                if new_rule and new_rule.format() != rule.format():
+                if new_rule:
                     rulemap[rule.id] = new_rule
                     modify_count += 1
 


### PR DESCRIPTION
Moved the modify part into the loop above to - seems to run way faster (15min instead of an hour and a half).

May be missing something, but removed the "if new_rule.format() != rule.format()" because it seemed like extra work to me. If a user has a modify that's messed up and produces the same rule all this does is run an if (in some cases 5000+ times) more, on top of the already poor rule running for nothing.

didn't do this - lmk if you want me to
  https://suricata-ids.org/about/contribution-agreement/
