### PR TITLE
Ticket 3174 - Duplicate filename handling - v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -205,11 +205,22 @@ class Fetch:
         if url:
             try:
                 fetched = self.fetch(url)
-                files.update(fetched)
+                for key in fetched:
+                    safe_filename = self.safe_filename(url[0], key)
+                    files[safe_filename] = fetched[key]
             except URLError as err:
                 url = url[0] if isinstance(url, tuple) else url
                 logger.error("Failed to fetch %s: %s", url, err)
         return files
+
+    def safe_filename(self, url, filename):
+        """Create a safe/conflict free filename from the URL and the full path
+        of a file inside the archive.
+        """
+        scheme_end = url.find("://")
+        if scheme_end > 0:
+            return "{}!{}".format(url[scheme_end + 1:], filename)
+        return "{}!{}".format(url, filename)
 
     def extract_files(self, filename):
         files = extract.try_extract(filename)

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -199,7 +199,7 @@ class Fetch:
         logger.info("Done.")
         return self.extract_files(tmp_filename)
 
-    def run(self, url=None, files=None):
+    def run(self, url, files=None):
         if files is None:
             files = {}
         if url:
@@ -209,9 +209,6 @@ class Fetch:
             except URLError as err:
                 url = url[0] if isinstance(url, tuple) else url
                 logger.error("Failed to fetch %s: %s", url, err)
-        else:
-            for url in self.args.url:
-                files.update(self.fetch(url))
         return files
 
     def extract_files(self, filename):

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
 commands = python ./tests/integration_tests.py

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-update/pull/212

Changes from last PR:
- Remove the URL scheme from the internal filename format to avoid
  links from being clickable.
- Remove Python 3.4 tests due to deprecations.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3174