### PR TITLE
Update docs to reflect current builds of Suricata

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -16,8 +16,9 @@ Pip can install ``suricata-update`` globally making it available to
 all users or it can install ``suricata-update`` into your home
 directory for use by your user.
 
-.. note:: At some point ``suricata-update`` should be bundled with
-          Suricata avoid the need for a separate installation.
+.. note:: Version 4.1+ from the Ubuntu PPA is bundled with
+          ``suricata-update``. At some point other packages should be
+	  bundled with Suricata avoid the need for a separate installation.
 
 To install ``suricata-update`` globally::
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -16,9 +16,7 @@ Pip can install ``suricata-update`` globally making it available to
 all users or it can install ``suricata-update`` into your home
 directory for use by your user.
 
-.. note:: Version 4.1+ from the Ubuntu PPA is bundled with
-          ``suricata-update``. At some point other packages should be
-	  bundled with Suricata avoid the need for a separate installation.
+.. note:: From version 4.1+ ``suricata-update`` is bundled with Suricata.
 
 To install ``suricata-update`` globally::
 


### PR DESCRIPTION
I'm not sure of the other packages, but the PPA on Launchpad has bundled suricata-update since 4.1.x.
https://launchpad.net/~oisf/+archive/ubuntu/suricata-stable

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [ ] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ ] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-
