### PR TITLE
Fixing --http-header option

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -764,7 +764,7 @@ def load_sources(suricata_version):
             params.update(internal_params)
             if "url" in source:
                 # No need to go off to the index.
-                http_header = source.get("http_header")
+                http_header = source.get("http-header")
                 checksum = source.get("checksum")
                 url = (source["url"] % params, http_header, checksum)
                 logger.debug("Resolved source %s to URL %s.", name, url[0])


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3696

Describe changes:
- In the main.py file, http_header was incorrectly being used as a key to get the http-header value from sources.  The key was updated to http-header to fix this.
