### PR TITLE
dataset parsing: handle spaces between "," - v1

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -420,7 +420,7 @@ def manage_classification(suriconf, files):
 def handle_dataset_files(rule, dep_files):
     if not rule.enabled:
         return
-    load_attr = [el for el in rule.dataset.split(",") if "load" in el][0]
+    load_attr = [el.strip() for el in rule.dataset.split(",") if "load" in el][0]
     dataset_fname = os.path.basename(load_attr.split(" ")[1])
     filename = [fname for fname, content in dep_files.items() if fname == dataset_fname]
     if filename:


### PR DESCRIPTION
Fix dataset parsing so the filename can be parsed from:
    
  dataset:isset, sslbl, type md5, load sslbl-fingerprints.md5;
