### PR TITLE
Deprecated and obsoleted source handling - v1

### DIFF
--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -32,7 +32,7 @@ def register(parser):
     parser.add_argument("--enabled", action="store_true",
                         help="List all enabled sources")
     parser.add_argument("--all", action="store_true",
-                        help="List all sources (including deprecated)")
+                        help="List all sources (including deprecated and obsolete)")
     parser.set_defaults(func=list_sources)
 
 def list_sources():
@@ -82,9 +82,10 @@ def list_sources():
         is_not_free = source.get("subscribe-url")
         if free_only and is_not_free:
             continue
-        deprecated = source.get("deprecated")
-        if deprecated is not None and not config.args().all:
-            continue
+        if not config.args().all:
+            if source.get("deprecated") is not None or \
+               source.get("obsolete") is not None:
+                continue
         print("%s: %s" % (util.bright_cyan("Name"), util.bright_magenta(name)))
         print("  %s: %s" % (
             util.bright_cyan("Vendor"), util.bright_magenta(source["vendor"])))
@@ -112,3 +113,7 @@ def list_sources():
             print("  %s: %s" % (
                 util.orange("Deprecated"),
                 util.bright_magenta(source["deprecated"])))
+        if "obsolete" in source:
+            print("  %s: %s" % (
+                util.orange("Obsolete"),
+                util.bright_magenta(source["obsolete"])))

--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -31,6 +31,8 @@ def register(parser):
                         default=False, help="List all freely available sources")
     parser.add_argument("--enabled", action="store_true",
                         help="List all enabled sources")
+    parser.add_argument("--all", action="store_true",
+                        help="List all sources (including deprecated)")
     parser.set_defaults(func=list_sources)
 
 def list_sources():
@@ -80,6 +82,9 @@ def list_sources():
         is_not_free = source.get("subscribe-url")
         if free_only and is_not_free:
             continue
+        deprecated = source.get("deprecated")
+        if deprecated is not None and not config.args().all:
+            continue
         print("%s: %s" % (util.bright_cyan("Name"), util.bright_magenta(name)))
         print("  %s: %s" % (
             util.bright_cyan("Vendor"), util.bright_magenta(source["vendor"])))
@@ -103,3 +108,7 @@ def list_sources():
             print("  %s: %s" % (
                 util.bright_cyan("Subscription"),
                 util.bright_magenta(source["subscribe-url"])))
+        if "deprecated" in source:
+            print("  %s: %s" % (
+                util.orange("Deprecated"),
+                util.bright_magenta(source["deprecated"])))

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -894,6 +894,10 @@ def load_sources(suricata_version):
                 if "deprecated" in source_config:
                     logger.warn("Source has been deprecated: %s: %s" % (
                         name, source_config["deprecated"]))
+                if "obsolete" in source_config:
+                    logger.warn("Source is obsolete and will not be fetched: %s: %s" % (
+                        name, source_config["obsolete"]))
+                    continue
                 logger.debug("Resolved source %s to URL %s.", name, url[0])
             urls.append(url)
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -891,6 +891,9 @@ def load_sources(suricata_version):
                     checksum = True
                 url = (index.resolve_url(name, params), http_header,
                        checksum)
+                if "deprecated" in source_config:
+                    logger.warn("Source has been deprecated: %s: %s" % (
+                        name, source_config["deprecated"]))
                 logger.debug("Resolved source %s to URL %s.", name, url[0])
             urls.append(url)
 

--- a/suricata/update/util.py
+++ b/suricata/update/util.py
@@ -93,3 +93,6 @@ def bright_magenta(msg):
 
 def bright_cyan(msg):
     return "%s%s%s" % (BRIGHT_CYAN, msg, RESET)
+
+def orange(msg):
+    return "%s%s%s" % (ORANGE, msg, RESET)


### PR DESCRIPTION
A deprecated source is one that still works but shouldn't be used. For example, it was renamed, or maybe is no longer recommended.  It will still be downloaded, etc, but a warning will be printed. We are using this to handle the rename of the abuse.ch listing as deprecated sources will no longer be displayed in the "list-sources".

Also add obsolete sources. These are sources that will no longer be fetched, with a warning displayed.  Useful for broken sources or something, that people may have enabled.
