### PR TITLE
ignore dot files for compatibility with mac based tars

### DIFF
--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -83,6 +83,7 @@ DEFAULT_CONFIG = {
     # The default file patterns to ignore.
     "ignore": [
         "*deleted.rules",
+        ".*"
     ],
 }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [ x ] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x ] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ x ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Update default ignore list to include dot files so that mac tars are compatible
