### PR TITLE
Add warning to update sources if no index found

### DIFF
--- a/suricata/update/commands/listsources.py
+++ b/suricata/update/commands/listsources.py
@@ -21,7 +21,6 @@ import logging
 from suricata.update import config
 from suricata.update import sources
 from suricata.update import util
-from suricata.update.commands.updatesources import update_sources
 from suricata.update import exceptions
 
 logger = logging.getLogger()
@@ -72,11 +71,9 @@ def list_sources():
 
     free_only = config.args().free
     if not sources.source_index_exists(config):
-        logger.info("No source index found, running update-sources")
-        try:
-            update_sources()
-        except exceptions.ApplicationError as err:
-            logger.warning("%s: will use bundled index.", err)
+        logger.warning("Source index does not exist, will use bundled one.")
+        logger.warning("Please run suricata-update update-sources.")
+        
     index = sources.load_source_index(config)
     for name, source in index.get_sources().items():
         is_not_free = source.get("subscribe-url")

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -63,7 +63,7 @@ assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache", "index.yaml")))
 # the index.
 delete(os.path.join(DATA_DIR, "update", "cache", "index.yaml"))
 run(common_args + ["list-sources"])
-assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache", "index.yaml")))
+assert(not os.path.exists(os.path.join(DATA_DIR, "update", "cache", "index.yaml")))
 
 # Enable a source.
 run(common_args + ["enable-source", "oisf/trafficid"])


### PR DESCRIPTION
- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3249

Describe changes:
- Similar to enable-source and check-versions commands that ask the user to run update-sources, added the fix in list-sources command to ask the user to run the update-sources command instead of updating the sources without asking the user.
