### PR TITLE
Database

### DIFF
--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -77,6 +77,7 @@ DEFAULT_CONFIG = {
     "enable-conf": "/etc/suricata/enable.conf",
     "drop-conf": "/etc/suricata/drop.conf",
     "modify-conf": "/etc/suricata/modify.conf",
+    "mysql-conf": "/etc/suricata/my.cnf",
     "sources": [],
     LOCAL_CONF_KEY: [],
 

--- a/suricata/update/configs/my.cnf
+++ b/suricata/update/configs/my.cnf
@@ -5,6 +5,7 @@
 
 [client]
 database = suricata_rules
-user = website
-password = W3bPa55
+user = user
+password = password
+host = localhost
 default-character-set = utf8

--- a/suricata/update/configs/my.cnf
+++ b/suricata/update/configs/my.cnf
@@ -1,0 +1,10 @@
+# suricata-update - my.cnf
+
+# Specify the mysql connection parameters here.
+# Database must exist first.
+
+[client]
+database = suricata_rules
+user = website
+password = W3bPa55
+default-character-set = utf8

--- a/suricata/update/configs/update.yaml
+++ b/suricata/update/configs/update.yaml
@@ -18,6 +18,9 @@ drop-conf: /etc/suricata/drop.conf
 # - Default: /etc/suricata/modify.conf
 modify-conf: /etc/suricata/modify.conf
 
+#Configuration perameters of mysql database (optional)
+mysql-conf: /etc/suricata/my.conf
+
 # List of files to ignore. Overrided by the --ignore command line option.
 ignore:
   - "*deleted.rules"

--- a/suricata/update/db.py
+++ b/suricata/update/db.py
@@ -1,0 +1,94 @@
+from __future__ import print_function
+
+import logging
+import mysql.connector
+
+logger = logging.getLogger(__name__)
+
+#list of SQL statements to interface with mysql
+
+db_statements = {
+    'create_table': 'CREATE TABLE signatures (id int NOT NULL AUTO_INCREMENT, sid varchar(10) NOT NULL UNIQUE, raw varchar(8192) NOT NULL, header varchar(2000) NOT NULL, priority int, msg varchar(280), enabled BOOLEAN default TRUE, gid int, classtype varchar(140), rev int, proto varchar(140), primary key (id));',
+
+    'insert_rule' : ("REPLACE INTO signatures "
+                     "(sid, classtype, header, msg, rev, raw, enabled, proto, priority, gid) "
+                     "VALUES (%(sid)s, %(classtype)s, %(header)s, %(msg)s, %(rev)s, %(raw)s, %(enabled)s, %(proto)s, %(priority)s, %(gid)s);"),
+
+    'count_rules_enabled' : 'SELECT count(*) FROM signatures where enabled = TRUE;',
+    'count_rules_disabled' : 'SELECT count(*) FROM signatures where enabled = FALSE;',
+    'count_rules_total' : 'SELECT count(*) FROM signatures',
+
+    'custom_query' : "UPDATE signatures set enabled = FALSE where proto like '%modbus%' or proto like '%dnp3%';" #eg to avoid protocol not supported error.
+}
+
+#Create a connection to a mysql database
+
+def create_connection(mysql_conf_file=""):
+    connection = mysql.connector.connect()
+    try:
+        connection = mysql.connector.connect(option_files=mysql_conf_file, auth_plugin='mysql_native_password')
+        logger.info("Success. Connected to mysql database.")
+    except Exception as err:
+        logger.warning("Failed to get a connection to the database: %s" % err)
+
+    return connection
+
+#Create the database table if it does not exist
+
+def create_rule_table(connection):
+    cursor = connection.cursor()
+    try:
+        cursor.execute(db_statements['create_table'])
+        connection.commit()
+        logger.info("Success. Signature table created.")
+    except Exception as e:
+        logger.warning("Database table not created: %s" % e)
+    cursor.close()
+
+#Process the rules that were generated in the main function by executing SQL insert statements against the cursor and then commit to the connection.
+
+def insert_rules(connection, rules):
+    cursor = connection.cursor()
+    success_count = 0
+    total_rules = len(rules)
+    logger.info("Inserting rules into the database.") # Let the user know that something is happening while the first rules are processed.
+    for rule in rules:
+        # Just check that there are no lists being passed into the database. It can't insert a list yet.
+        for key, value in rule.items():
+            if isinstance(value, list):
+                rule[key] = str(rule[key])
+        try:
+            cursor.execute(db_statements['insert_rule'], rule) #Insert a rule into the database.
+            success_count = success_count + 1
+            if success_count % 1000 == 0:
+                logger.info("Successfully added %s rules." % success_count)
+        except mysql.connector.IntegrityError as err: #Duplicate. Some additional logic could be supplied to deal with that, but we use REPLACE if to take the newer version violates the unique constriant on SID.
+            logger.info("Something wrong with inserting rule: %s " %err)
+        except Exception as err: #Error. Report that rule wasn't inserted into the database.
+            logger.info("Failed to insert rule into database: " + str(rule['sid']) + " " + str(err))
+
+    connection.commit() #Commit once to the database. Important or else the data won't be committed.
+    cursor.close()
+
+#Report some stats about the rules we have.
+
+def get_database_stats(connection):
+    cursor = connection.cursor()
+    cursor.execute(db_statements['count_rules_enabled'])
+    for value in cursor:
+        logger.info("# Enabled rules in the database: %s" % value)
+    cursor.execute(db_statements['count_rules_disabled'])
+    for value in cursor:
+        logger.info("# Disabled rules in the database: %s" % value)
+    cursor.execute(db_statements['count_rules_total'])
+    for value in cursor:
+        logger.info("# Total rules in the database: %s" % value)
+    cursor.close()
+
+#Run a custom query to post-process the results. This is optional & exists to clean up the database after re-adding rules.
+
+def run_custom_query(connection):
+    cursor = connection.cursor()
+    cursor.execute(db_statements['custom_query'])
+    connection.commit()
+    cursor.close()

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -65,7 +65,7 @@ from suricata.update import (
     matchers as matchers_mod
 )
 
-from suricata.update import db
+from suricata.update.db import *
 
 from suricata.update.version import version
 try:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1243,7 +1243,7 @@ def _main():
             pass #do no custom sql if not neccessary.
         try:
             connection.close()
-        except:
+        except Exception as err:
             logger.warning("Did not close connection, please check your connection string: %s" % err)
     else: #database was not an option passed in by the user to suricata-update.
         pass

--- a/suricata/update/parsers.py
+++ b/suricata/update/parsers.py
@@ -141,6 +141,16 @@ update_arg = [
     (("--offline",),
      {'action': 'store_true',
       'help': "Run offline using most recent cached rules"}),
+    #Add database arguments to the optional list of things to do
+    (("--mysqlconf",),
+     {'metavar': '<filename>',
+      'help': "Filename of the mysql database connection parameters."}),
+    (("--database",),
+     {'action': 'store_true', 'default': False,
+      'help': "Load rules into a mysql database."}),
+    (("--database-custom",),
+     {'action': 'store_true', 'default': False,
+      'help': "Run custom sql on database to post process entries."}),
 
     # Hidden argument, --now to bypass the timebased bypass of
     # updating a ruleset.


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Implemented a db.py file in suricata-update to allow the updated ruleset to be pushed into a mysql database.
- User should supply connection settings in  a my.cnf file and place it in /etc/suricata to be read by the suricata-update program
- If running suricata-update, the user can optionally supply a --database or --mysqlconf or --database-custom command to have these options run. (--database is enough to create a table in the supplied database and populate it with the rules fetched by suricata-update).
- Database needs to exist in order for the command to run, but anyone can run "create database suricata".
- Fields in database include the raw rule, protocol, header, sid, msg, enabled, priority, gid, classtype, rev.
- Database gets populated with the most recent rules fetched by suricata-update. 
- In future, hopefully suricata can connect to the database and read those rules fetched by suricata-update!
