### PR TITLE
fix: fix --no-merge option - v1

### DIFF
--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -51,6 +51,13 @@ assert(os.path.exists(DATA_DIR))
 assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache")))
 assert(os.path.exists(os.path.join(DATA_DIR, "rules", "suricata.rules")))
 
+# Default run with data directory and --no-merge
+run(common_args + common_update_args + ["--no-merge"])
+assert(os.path.exists(DATA_DIR))
+assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache")))
+assert(os.path.exists(os.path.join(DATA_DIR, "rules", "emerging-deleted.rules")))
+assert(os.path.exists(os.path.join(DATA_DIR, "rules", "emerging-current_events.rules")))
+
 # Still a default run, but set --output to an alternate location."
 run(common_args + common_update_args + ["--output", "./tests/tmp/_rules"])
 assert(os.path.exists(os.path.join(DATA_DIR, "_rules")))


### PR DESCRIPTION
The no-merge handling was not updated when the file storage
was converted to a list causing it to fail.

Also add a --no-merge test to our integration test.

Fixes issue:
https://redmine.openinfosecfoundation.org/issues/4324
