### PR TITLE
HTTP BasicAuth Support final

### DIFF
--- a/doc/add-source.rst
+++ b/doc/add-source.rst
@@ -25,6 +25,10 @@ Options
 
      add-source --http-header "X-API-Key: 1234"
 
+   HTTP basic authentication can be achieved by setting the HTTP Basic
+   Authentication header with ``base64(user1:password1)``. Example::
+     add-source --http-header "Authorization: Basic dXNlcjE6cGFzc3dvcmQx"
+
 .. option:: --no-checksum
 
    Skips downloading the checksum URL for the rule source.

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -91,7 +91,7 @@ def is_header_clean(header):
     if len(header) != 2:
         return False
     name, val = header[0].strip(), header[1].strip()
-    if re.match( r"^[\w-]+$", name) and re.match(r"^[\w-]+$", val):
+    if re.match( r"^[\w-]+$", name) and re.match(r"^[\w\s-]+$", val):
         return True
     return False
 


### PR DESCRIPTION
Allow whitespaces in entire HTTP header value.

This enables HTTP Basic Authentication.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/4362

Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4362

Describe changes:
- Add HTTP Basic Authentication by setting HTTP header as follows:
  `suricata-update add-source --http-header "Authorization: Basic dXNlcjE6cGFzc3dvcmQx"`
- This was currently not possible, since `is_header_clean(header)` does not allow any whitespaces in headers, but we have one between `Basic *base64*`.
- Improvment allows whitespaces in the entire HTTP header at all.
