### PR TITLE
Use HTTP-Headers for checksum request

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -106,12 +106,13 @@ class Fetch:
 
     def check_checksum(self, tmp_filename, url):
         try:
-            checksum_url = url + ".md5"
+            checksum_url = url[0] + ".md5"
+            net_arg=(checksum_url,url[1])
             local_checksum = hashlib.md5(
                 open(tmp_filename, "rb").read()).hexdigest().strip()
             remote_checksum_buf = io.BytesIO()
             logger.info("Checking %s." % (checksum_url))
-            net.get(checksum_url, remote_checksum_buf)
+            net.get(net_arg, remote_checksum_buf)
             remote_checksum = remote_checksum_buf.getvalue().decode().strip()
             logger.debug("Local checksum=|%s|; remote checksum=|%s|" % (
                 local_checksum, remote_checksum))
@@ -174,7 +175,7 @@ class Fetch:
                     url)
                 return self.extract_files(tmp_filename)
             if checksum:
-                if self.check_checksum(tmp_filename, url):
+                if self.check_checksum(tmp_filename, net_arg):
                     logger.info("Remote checksum has not changed. "
                                 "Not fetching.")
                     return self.extract_files(tmp_filename)


### PR DESCRIPTION
Noticed this bug in our deployment. As it was already raised but not WIP in redmine, I decided to give fixing it a shot.

Let me know if there are any issues with this bugfix that I should address.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4001

Describe changes:
- use `net_arg` (tuple) instead of `url` (string) as parameter for `check_checksum()`
- create new tuple with modified URL in `check_checksum()`
- call `net.get()` with tuple instead of URL