### PR TITLE
Doc: Improve documentation of Suricata reload.

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -122,7 +122,8 @@ This command will:
 
 .. note:: Suricata-Update is also capable of triggering a rule reload,
           but doing so requires some extra configuration that will be
-          covered later.
+          covered later. See the documentation of
+          :command:`--reload-command=<command>` for more details.
 
 Configure Suricata to Load Suricata-Update Managed Rules
 ========================================================

--- a/doc/update.rst
+++ b/doc/update.rst
@@ -153,11 +153,25 @@ Options
 .. option:: --reload-command=<command>
 
    A command to run after the rules have been updated; will not run if
-   no change to the output files was made.  For example::
+   no change to the output files was made. For example::
 
-     --reload-command='sudo kill -USR2 $(cat /var/run/suricata.pid)'
+     --reload-command='sudo kill -USR2 $(pidof suricata)'
 
    will tell Suricata to reload its rules.
+
+   Furthermore the reload can be triggered using the Unix socket of Suricata.
+
+   Blocking reload (with Suricata waiting for the reload to finish)::
+
+     --reload-command='sudo suricatasc -c reload-rules'
+
+   Non blocking reload (without restarting Suricata)::
+
+     --reload-command='sudo suricatasc -c ruleset-reload-nonblocking'
+
+   See the Suricata documentation on `Rule Reloads
+   <https://suricata.readthedocs.io/en/latest/rule-management/rule-reload.html>`_
+   for more information.
 
 .. option:: --no-reload
 

--- a/suricata/update/configs/update.yaml
+++ b/suricata/update/configs/update.yaml
@@ -36,6 +36,8 @@ ignore:
 
 # Provide a command to reload the Suricata rules.
 # May be overrided by the --reload-command command line option.
+# See the documentation of --reload-command for the different options
+# to reload Suricata rules.
 #reload-command: sudo systemctl reload suricata
 
 # Remote rule sources. Simply a list of URLs.


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [X] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4564

Describe changes:
- The documentation of Suricata-Update only names the "kill" command for a Suricata reload.
- But according to the official Suricata documentation, there are much more commands for reloading.
  https://suricata-update.readthedocs.io/en/latest/update.html?highlight=reload#cmdoption-reload-command
- With this MR I will try to improve the documentation of Suricata-Update to clarify this.
- See ticket for more details and the reasons

I would appreciate any feedback on how this documentation can be improved even more.