### PR TITLE
Fix: Add missing newline to avoid sphinx warning.

### DIFF
--- a/doc/add-source.rst
+++ b/doc/add-source.rst
@@ -27,6 +27,7 @@ Options
 
    HTTP basic authentication can be achieved by setting the HTTP Basic
    Authentication header with ``base64(user1:password1)``. Example::
+
      add-source --http-header "Authorization: Basic dXNlcjE6cGFzc3dvcmQx"
 
 .. option:: --no-checksum


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [X] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4565

Describe changes:
- Avoids warning when building docs with `sphinx`
- This was caused by a missing newline in my last MR
- Sorry 😞 