### PR TITLE
Feature 4701

### DIFF
--- a/doc/add-source.rst
+++ b/doc/add-source.rst
@@ -24,6 +24,12 @@ Options
    as a custom API key. Example::
 
      add-source --http-header "X-API-Key: 1234"
+   
+   HTTP Bearer authentication can be used by setting the HTTP Bearer Authentication header 
+   with a OAuth2 token containing printable ASCII characters. Example::
+
+      add-source --http-header "Auhorization: Bearer NjA2MTUOTAx?D+wOm4U/vpXQy0xhl!hSaR7#ENVpK59"
+      
 
 .. option:: --no-checksum
 

--- a/doc/add-source.rst
+++ b/doc/add-source.rst
@@ -25,6 +25,10 @@ Options
 
      add-source --http-header "X-API-Key: 1234"
    
+   HTTP basic authentication can be achieved by setting the HTTP Basic Authentication header with base64(user1:password1). Example::
+
+      add-source --http-header "Authorization: Basic dXNlcjE6cGFzc3dvcmQx"
+   
    HTTP Bearer authentication can be used by setting the HTTP Bearer Authentication header 
    with a OAuth2 token containing printable ASCII characters. Example::
 

--- a/suricata/update/net.py
+++ b/suricata/update/net.py
@@ -91,7 +91,7 @@ def is_header_clean(header):
     if len(header) != 2:
         return False
     name, val = header[0].strip(), header[1].strip()
-    if re.match( r"^[\w-]+$", name) and re.match(r"^[\w-]+$", val):
+    if re.match( r"^[\w-]+$", name) and re.match(r"^[\w\s -~]+$", val):
         return True
     return False
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [Feature #4701](https://redmine.openinfosecfoundation.org/issues/4701)

Describe changes:

Changed the regex in is_header_clean(header) to include printable ASCII characters - this fixes HTTP basic authentication where the base64 encoded user:password output includes special characters + / and also allows support for HTTP Bearer Auth flow where the OAuth2 token contains any ASCII printable characters.