### PR TITLE
Issue 4259 - Fix double modification of rules - v2

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1193,15 +1193,15 @@ def _main():
 
         for fltr in drop_filters:
             if fltr.match(rule):
-                rulemap[rule.id] = fltr.run(rule)
+                rule = fltr.run(rule)
                 drop_count += 1
 
         for fltr in modify_filters:
             if fltr.match(rule):
-                new_rule = fltr.run(rule)
-                if new_rule:
-                    rulemap[rule.id] = new_rule
-                    modify_count += 1
+                rule = fltr.run(rule)
+                modify_count += 1
+
+        rulemap[key] = rule
 
     # Check if we should disable ja3 rules.
     try:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1179,6 +1179,12 @@ def _main():
 
     for key, rule in rulemap.items():
 
+        # To avoid duplicate counts when a rule has more than one modification
+        # to it, we track the actions here then update the counts at the end.
+        enabled = False
+        modified = False
+        dropped = False
+
         for matcher in disable_matchers:
             if rule.enabled and matcher.match(rule):
                 logger.debug("Disabling: %s" % (rule.brief()))
@@ -1189,17 +1195,24 @@ def _main():
             if not rule.enabled and matcher.match(rule):
                 logger.debug("Enabling: %s" % (rule.brief()))
                 rule.enabled = True
-                enable_count += 1
+                enabled = True
 
         for fltr in drop_filters:
             if fltr.match(rule):
                 rule = fltr.run(rule)
-                drop_count += 1
+                dropped = True
 
         for fltr in modify_filters:
             if fltr.match(rule):
                 rule = fltr.run(rule)
-                modify_count += 1
+                modified = True
+
+        if enabled:
+            enable_count += 1
+        if modified:
+            modify_count += 1
+        if dropped:
+            drop_count += 1
 
         rulemap[key] = rule
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -5,8 +5,10 @@ import shutil
 
 DATA_DIR = "./tests/tmp"
 
+
 def run(args):
     subprocess.check_call(args)
+
 
 def delete(path):
     if os.path.isdir(path):
@@ -14,13 +16,13 @@ def delete(path):
     else:
         os.unlink(path)
 
+
 print("Python executable: %s" % sys.executable)
 print("Python version: %s" % str(sys.version))
 print("Current directory: %s" % os.getcwd())
 
 # Override the default source index URL to avoid hitting the network.
-os.environ["SOURCE_INDEX_URL"] = "file://%s/tests/index.yaml" % (
-    os.getcwd())
+os.environ["SOURCE_INDEX_URL"] = "file://%s/tests/index.yaml" % (os.getcwd())
 
 os.environ["ETOPEN_URL"] = "file://%s/tests/emerging.rules.tar.gz" % (
     os.getcwd())
@@ -31,76 +33,86 @@ if os.path.exists(DATA_DIR):
 common_args = [
     sys.executable,
     "./bin/suricata-update",
-    "-D", DATA_DIR,
-    "-c", "./tests/empty",
+    "-D",
+    DATA_DIR,
+    "-c",
+    "./tests/empty",
 ]
 
 common_update_args = [
     "--no-test",
     "--no-reload",
-    "--suricata-conf", "./tests/suricata.yaml",
-    "--disable-conf", "./tests/disable.conf",
-    "--enable-conf", "./tests/empty",
-    "--drop-conf", "./tests/empty",
-    "--modify-conf", "./tests/empty",
+    "--suricata-conf",
+    "./tests/suricata.yaml",
+    "--disable-conf",
+    "./tests/disable.conf",
+    "--enable-conf",
+    "./tests/empty",
+    "--drop-conf",
+    "./tests/empty",
+    "--modify-conf",
+    "./tests/empty",
 ]
 
 # Default run with data directory.
 run(common_args + common_update_args)
-assert(os.path.exists(DATA_DIR))
-assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache")))
-assert(os.path.exists(os.path.join(DATA_DIR, "rules", "suricata.rules")))
+assert (os.path.exists(DATA_DIR))
+assert (os.path.exists(os.path.join(DATA_DIR, "update", "cache")))
+assert (os.path.exists(os.path.join(DATA_DIR, "rules", "suricata.rules")))
 
 # Default run with data directory and --no-merge
 run(common_args + common_update_args + ["--no-merge"])
-assert(os.path.exists(DATA_DIR))
-assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache")))
-assert(os.path.exists(os.path.join(DATA_DIR, "rules", "emerging-deleted.rules")))
-assert(os.path.exists(os.path.join(DATA_DIR, "rules", "emerging-current_events.rules")))
+assert (os.path.exists(DATA_DIR))
+assert (os.path.exists(os.path.join(DATA_DIR, "update", "cache")))
+assert (os.path.exists(
+    os.path.join(DATA_DIR, "rules", "emerging-deleted.rules")))
+assert (os.path.exists(
+    os.path.join(DATA_DIR, "rules", "emerging-current_events.rules")))
 
 # Still a default run, but set --output to an alternate location."
 run(common_args + common_update_args + ["--output", "./tests/tmp/_rules"])
-assert(os.path.exists(os.path.join(DATA_DIR, "_rules")))
+assert (os.path.exists(os.path.join(DATA_DIR, "_rules")))
 
 # Update sources.
 run(common_args + ["update-sources"])
-assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache", "index.yaml")))
+assert (os.path.exists(os.path.join(DATA_DIR, "update", "cache",
+                                    "index.yaml")))
 
 # Now delete the index and run lists-sources to see if it downloads
 # the index.
 delete(os.path.join(DATA_DIR, "update", "cache", "index.yaml"))
 run(common_args + ["list-sources"])
-assert(os.path.exists(os.path.join(DATA_DIR, "update", "cache", "index.yaml")))
+assert (os.path.exists(os.path.join(DATA_DIR, "update", "cache",
+                                    "index.yaml")))
 
 # Enable a source.
 run(common_args + ["enable-source", "oisf/trafficid"])
-assert(os.path.exists(
+assert (os.path.exists(
     os.path.join(DATA_DIR, "update", "sources", "oisf-trafficid.yaml")))
 
 # Disable the source.
 run(common_args + ["disable-source", "oisf/trafficid"])
-assert(not os.path.exists(
-    os.path.join(
-        DATA_DIR, "update", "sources", "oisf-trafficid.yaml")))
-assert(os.path.exists(
-    os.path.join(
-        DATA_DIR, "update", "sources", "oisf-trafficid.yaml.disabled")))
+assert (not os.path.exists(
+    os.path.join(DATA_DIR, "update", "sources", "oisf-trafficid.yaml")))
+assert (os.path.exists(
+    os.path.join(DATA_DIR, "update", "sources",
+                 "oisf-trafficid.yaml.disabled")))
 
 # Remove the source.
 run(common_args + ["remove-source", "oisf/trafficid"])
-assert(not os.path.exists(
-    os.path.join(
-        DATA_DIR, "update", "sources", "oisf-trafficid.yaml.disabled")))
+assert (not os.path.exists(
+    os.path.join(DATA_DIR, "update", "sources",
+                 "oisf-trafficid.yaml.disabled")))
 
 # Add a source with a custom header.
 run(common_args + [
     "add-source", "--http-header", "Header: NoSpaces",
-    "testing-header-nospaces",
-    "file:///doesnotexist"])
+    "testing-header-nospaces", "file:///doesnotexist"
+])
 
 # Add a source with a custom header with spaces in the value
 # (https://redmine.openinfosecfoundation.org/issues/4362)
 run(common_args + [
-    "add-source",
-    "--http-header", "Authorization: Basic dXNlcjE6cGFzc3dvcmQx",
-    "testing-header-with-spaces", "file:///doesnotexist"])
+    "add-source", "--http-header", "Authorization: Basic dXNlcjE6cGFzc3dvcmQx",
+    "testing-header-with-spaces", "file:///doesnotexist"
+])


### PR DESCRIPTION
Fix the case where only the last modification made to a rule takes effect. This
occurs when 2 modification lines change a rule, or a modification plus a drop
changes a rule.

Ticket: https://redmine.openinfosecfoundation.org/issues/4259
