### PR TITLE
Allow user to log detailed rule report

### DIFF
--- a/suricata/update/parsers.py
+++ b/suricata/update/parsers.py
@@ -63,6 +63,8 @@ global_arg = [
      {'metavar': '<user-agent>',
       'help': "Set custom user-agent string" 
       if show_advanced else argparse.SUPPRESS}),
+     (("--report",), {'metavar': '<filename>',
+      'help': "Filename of the report for rules"}),
     (("--no-check-certificate",),
      {'action': 'store_true', 'default': None,
       'help': "Disable server SSL/TLS certificate verification"


### PR DESCRIPTION
Add a `--report <filename>` option so that the end user is able to log a
report about the rules enabled, disabled, modified and dropped.
Usage
```
$ suricata-update --report /tmp/rules.log
```

Sample Report

```
Suricata-Update Summary - Thursday, 24 Mar 2022, 13:20:30

Summary
=======
Rules disabled by disable.conf: 148
Rules enabled by enable.conf: 0
Rules modified by modify.conf: 0
Rules converted to drop: 0
Rules enabled for flowbit dependencies: 131
Rules added: 274
Rules removed: 17
Rules modified: 1721

Added Rules
-----------
[1:2500036] ET COMPROMISED Known Compromised or Hostile Host Traffic group 19 (compromised.rules)
[1:2500038] ET COMPROMISED Known Compromised or Hostile Host Traffic group 20 (compromised.rules)

```
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2256

Previous PR: https://github.com/OISF/suricata-update/pull/300

Changes since v9:
- Updated changed variable name all through the function