### PR TITLE
dataset handling - v4

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -424,8 +424,19 @@ def manage_classification(suriconf, files):
 def handle_dataset_files(rule, dep_files):
     if not rule.enabled:
         return
-    load_attr = [el.strip() for el in rule.dataset.split(",") if "load" in el][0]
-    dataset_fname = os.path.basename(load_attr.split(" ")[1])
+    load_attr = [el.strip() for el in rule.dataset.split(",") if el.startswith("load")]
+    state_attr = [el.strip() for el in rule.dataset.split(",") if el.startswith("state")]
+    if not load_attr and not state_attr:
+        return
+    if load_attr and state_attr:
+        logger.error("Invalid dataset rule")
+        return
+    elif load_attr:
+        ds_attr = load_attr[0]
+    elif state_attr:
+        ds_attr = state_attr[0]
+
+    dataset_fname = os.path.basename(ds_attr.split(" ")[1])
     filename = [fname for fname, content in dep_files.items() if fname == dataset_fname]
     if filename:
         logger.debug("Copying dataset file %s to output directory" % dataset_fname)


### PR DESCRIPTION
A continuation of https://github.com/OISF/suricata-update/pull/298.

Ticket: https://redmine.openinfosecfoundation.org/issues/5010

Changes from last PR:
- Fixes path handling.
- Saves the dataset file as the md5 hash of the contents and rewrites the rule accordingly to prevent duplicate dataset filenames among rulesets overwriting each other.

I'm not wondering if it would be more use friendly to put the dataset files in a directory named after the source, instead of using a hash as the filename. That would cover the duplicate case better.

