### PR TITLE
Modify filter to add new metatdata - v1

### DIFF
--- a/suricata/update/configs/modify.conf
+++ b/suricata/update/configs/modify.conf
@@ -18,3 +18,7 @@
 # For compatibility, most Oinkmaster modifysid lines should work as
 # well.
 # modifysid * "^drop(.*)noalert(.*)" | "alert${1}noalert${2}"
+
+# Add metadata.
+#metadata-add re:"SURICATA STREAM" "evebox-action" "archive"
+#metadata-add 2010646 "evebox-action" "archive"

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -242,12 +242,16 @@ def load_filters(filename):
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            line = line.rsplit(" #")[0]
+            line = line.rsplit(" #")[0].strip()
 
-            line = re.sub(r'\\\$', '$', line)  # needed to escape $ in pp
             try:
-                rule_filter = matchers_mod.ModifyRuleFilter.parse(line)
-                filters.append(rule_filter)
+                if line.startswith("metadata-add"):
+                    rule_filter = matchers_mod.AddMetadataFilter.parse(line)
+                    filters.append(rule_filter)
+                else:
+                    line = re.sub(r'\\\$', '$', line)  # needed to escape $ in pp
+                    rule_filter = matchers_mod.ModifyRuleFilter.parse(line)
+                    filters.append(rule_filter)
             except Exception as err:
                 raise exceptions.ApplicationError(
                     "Failed to parse modify filter: {}".format(line))

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -424,8 +424,19 @@ def manage_classification(suriconf, files):
 def handle_dataset_files(rule, dep_files):
     if not rule.enabled:
         return
-    load_attr = [el.strip() for el in rule.dataset.split(",") if "load" in el][0]
-    dataset_fname = os.path.basename(load_attr.split(" ")[1])
+    load_attr = [el.strip() for el in rule.dataset.split(",") if el.startswith("load")]
+    state_attr = [el.strip() for el in rule.dataset.split(",") if el.startswith("state")]
+    if not load_attr and not state_attr:
+        return
+    if load_attr and state_attr:
+        logger.error("Invalid dataset rule")
+        return
+    elif load_attr:
+        ds_attr = load_attr[0]
+    elif state_attr:
+        ds_attr = state_attr[0]
+
+    dataset_fname = os.path.basename(ds_attr.split(" ")[1])
     filename = [fname for fname, content in dep_files.items() if fname == dataset_fname]
     if filename:
         logger.debug("Copying dataset file %s to output directory" % dataset_fname)

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -107,3 +107,15 @@ class IdRuleMatcherTestCase(unittest.TestCase):
 
         matcher = matchers_mod.IdRuleMatcher.parse("1:a")
         self.assertIsNone(matcher)
+
+class MetadataAddTestCase(unittest.TestCase):
+
+    def test_shlex(self):
+        rule_string = 'alert tcp any any -> any any (msg:"SURICATA STREAM Packet is retransmission"; stream-event:pkt_retransmission; flowint:tcp.retransmission.count,+,1; noalert; classtype:protocol-command-decode; sid:2210053; rev:1;)'
+        rule = suricata.update.rule.parse(rule_string)
+        text = 'metadata-add re:"SURICATA STREAM" "evebox.action" "archive"'
+        metadata_filter = matchers_mod.AddMetadataFilter.parse(text)
+        self.assertTrue(metadata_filter.match(rule))
+        new_rule = metadata_filter.run(rule)
+        self.assertIsNotNone(new_rule)
+        self.assertTrue(new_rule.format().find("evebox.action") > -1)


### PR DESCRIPTION
A new addition to `modify.conf` that allows for adding a new metadata.
    
Example configuration lines:
      metadata-add re:"SURICATA STREAM" "evebox.action" "archive"
      metadata-add 2010646 "evebox.action" "archive"
    
Matching rules will have a new `metadata` section added onto the end of the rule.

Ticket: https://redmine.openinfosecfoundation.org/issues/5221