### PR TITLE
1.2.x/next/v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
   https://redmine.openinfosecfoundation.org/issues/4259
 - Fix "check-versions" where the running Suricata is newer than what the index
   knows about: https://redmine.openinfosecfoundation.org/issues/4373
+- Fix issue with dataset handling. Also adds file renaming to avoid conflicts:
+  https://redmine.openinfosecfoundation.org/issues/5010.
+- New modify option to add metadata:
+  https://redmine.openinfosecfoundation.org/issues/5221.
+- Respect Suricata's sysconfdir when loading configuration files:
+  https://redmine.openinfosecfoundation.org/issues/4374.
 
 ## 1.2.3 - 2021-11-05
 - Allow more custom characters in custom http header to allow for more

--- a/suricata/update/config.py
+++ b/suricata/update/config.py
@@ -226,6 +226,24 @@ def init(args):
             logger.info("Using data-directory %s.", data_directory)
             _config[DATA_DIRECTORY_KEY] = data_directory
 
+        # Fixup the default locations for Suricata-Update configuration files, but only if
+        # they exist, otherwise keep the defaults.
+        if "sysconfdir" in build_info:
+            configs = (
+                ("disable-conf", "disable.conf"),
+                ("enable-conf", "enable.conf"),
+                ("drop-conf", "drop.conf"),
+                ("modify-conf", "modify.conf"),
+            )
+            sysconfdir = build_info["sysconfdir"]
+            for key, filename in configs:
+                config_path = os.path.join(sysconfdir, "suricata", filename)
+                if os.path.exists(config_path):
+                    is_arg = getattr(args, key.replace("-", "_"))
+                    if is_arg is None:
+                        logger.debug("Changing default for {} to {}".format(key, config_path))
+                        _config[key] = config_path
+
     # If suricata-conf not provided on the command line or in the
     # configuration file, look for it.
     if not "suricata-conf" in _config:

--- a/suricata/update/configs/modify.conf
+++ b/suricata/update/configs/modify.conf
@@ -18,3 +18,7 @@
 # For compatibility, most Oinkmaster modifysid lines should work as
 # well.
 # modifysid * "^drop(.*)noalert(.*)" | "alert${1}noalert${2}"
+
+# Add metadata.
+#metadata-add re:"SURICATA STREAM" "evebox-action" "archive"
+#metadata-add 2010646 "evebox-action" "archive"

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -242,12 +242,16 @@ def load_filters(filename):
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            line = line.rsplit(" #")[0]
+            line = line.rsplit(" #")[0].strip()
 
-            line = re.sub(r'\\\$', '$', line)  # needed to escape $ in pp
             try:
-                rule_filter = matchers_mod.ModifyRuleFilter.parse(line)
-                filters.append(rule_filter)
+                if line.startswith("metadata-add"):
+                    rule_filter = matchers_mod.AddMetadataFilter.parse(line)
+                    filters.append(rule_filter)
+                else:
+                    line = re.sub(r'\\\$', '$', line)  # needed to escape $ in pp
+                    rule_filter = matchers_mod.ModifyRuleFilter.parse(line)
+                    filters.append(rule_filter)
             except Exception as err:
                 raise exceptions.ApplicationError(
                     "Failed to parse modify filter: {}".format(line))

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 Open Information Security Foundation
+# Copyright (C) 2017-2022 Open Information Security Foundation
 # Copyright (c) 2015-2017 Jason Ish
 #
 # You can copy, redistribute or modify this Program under the terms of
@@ -456,7 +456,8 @@ def handle_dataset_files(rule, dep_files):
             fp.write(dep_files[source_filename].decode("utf-8"))
         return new_rule
     else:
-        logger.error("Dataset file '{}' was not found".format(dataset_filename))
+        logger.warn("Dataset file '{}' was not found for rule {}, rule will be disabled".format(dataset_filename, rule.idstr))
+        rule.enabled = False
 
 def handle_filehash_files(rule, dep_files, fhash):
     if not rule.enabled:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -424,8 +424,19 @@ def manage_classification(suriconf, files):
 def handle_dataset_files(rule, dep_files):
     if not rule.enabled:
         return
-    load_attr = [el.strip() for el in rule.dataset.split(",") if "load" in el][0]
-    dataset_fname = os.path.basename(load_attr.split(" ")[1])
+    load_attr = [el.strip() for el in rule.dataset.split(",") if el.startswith("load")]
+    state_attr = [el.strip() for el in rule.dataset.split(",") if el.startswith("state")]
+    if not load_attr and not state_attr:
+        return
+    if load_attr and state_attr:
+        logger.error("Invalid dataset rule")
+        return
+    elif load_attr:
+        ds_attr = load_attr[0]
+    elif state_attr:
+        ds_attr = state_attr[0]
+
+    dataset_fname = os.path.basename(ds_attr.split(" ")[1])
     filename = [fname for fname, content in dep_files.items() if fname == dataset_fname]
     if filename:
         logger.debug("Copying dataset file %s to output directory" % dataset_fname)

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -107,3 +107,15 @@ class IdRuleMatcherTestCase(unittest.TestCase):
 
         matcher = matchers_mod.IdRuleMatcher.parse("1:a")
         self.assertIsNone(matcher)
+
+class MetadataAddTestCase(unittest.TestCase):
+
+    def test_metadata_add(self):
+        rule_string = 'alert tcp any any -> any any (msg:"SURICATA STREAM Packet is retransmission"; stream-event:pkt_retransmission; flowint:tcp.retransmission.count,+,1; noalert; classtype:protocol-command-decode; sid:2210053; rev:1;)'
+        rule = suricata.update.rule.parse(rule_string)
+        text = 'metadata-add re:"SURICATA STREAM" "evebox.action" "archive"'
+        metadata_filter = matchers_mod.AddMetadataFilter.parse(text)
+        self.assertTrue(metadata_filter.match(rule))
+        new_rule = metadata_filter.run(rule)
+        self.assertIsNotNone(new_rule)
+        self.assertTrue(new_rule.format().find("evebox.action") > -1)


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-update/pull/306

Changes from last PR:
- Disable the rule if the dataset file cannot be copied over to keep the Suricata -T passing, so the rest of the rules get updated.

Includes:
- https://github.com/OISF/suricata-update/pull/304
- https://github.com/OISF/suricata-update/pull/303
- Simplified variation of https://github.com/OISF/suricata-update/pull/287