### PR TITLE
entry point: update sys.path for non-distutils install

### DIFF
--- a/bin/suricata-update
+++ b/bin/suricata-update
@@ -20,12 +20,15 @@ import sys
 import os
 
 exec_dir = os.path.dirname(__file__)
-version_info = sys.version_info
-pyver = "%d.%d" % (version_info.major, version_info.minor)
-site_path = "%s/../lib/python%s/site-packages" % (exec_dir, pyver)
 
-if os.path.exists("%s/suricata/update" % (site_path)):
-    sys.path.insert(0, site_path)
+# Check if we were installed along with Suricata, and setup the path if so.
+libpath = os.path.realpath(
+    os.path.join(exec_dir, os.pardir, "lib/suricata/python"))
+if os.path.exists(os.path.join(libpath, "suricata", "update")):
+    sys.path.insert(0, libpath)
+
+# If running out of the source directory, make sure we pick up the
+# library from the current directory.
 sys.path.insert(
     0, os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0]))))
 


### PR DESCRIPTION
When bundled with Suricata, Suricata-Update will not be installed with
distutils/setuptools and will be installed in a custom location. Update
the search path for these changes.

This will still work correctly if installed from pip, or running from a
custom directory not bundled with Suricata.

Required for Suricata PR: https://github.com/OISF/suricata/pull/7371

Issue: #5313
