### PR TITLE
Allow checksum URL to be provided in the index - v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,5 +247,5 @@ jobs:
       - run: pip3 install PyYAML
       - run: pip3 install pytest
       - uses: actions/checkout@v1
-      - run: PYTHONPATH=. pytest
+      - run: PYTHONPATH=. python3 -m pytest
       - run: PYTHONPATH=. python3 ./tests/integration_tests.py

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -109,9 +109,10 @@ class Fetch:
     def __init__(self):
         self.istty = os.isatty(sys.stdout.fileno())
 
-    def check_checksum(self, tmp_filename, url):
+    def check_checksum(self, tmp_filename, url, checksum_url=None):
         try:
-            checksum_url = url[0] + ".md5"
+            if not isinstance(checksum_url, str):
+                checksum_url = url[0] + ".md5"
             net_arg=(checksum_url,url[1])
             local_checksum = hashlib.md5(
                 open(tmp_filename, "rb").read()).hexdigest().strip()
@@ -180,7 +181,7 @@ class Fetch:
                     url)
                 return self.extract_files(tmp_filename)
             if checksum:
-                if self.check_checksum(tmp_filename, net_arg):
+                if self.check_checksum(tmp_filename, net_arg, checksum):
                     logger.info("Remote checksum has not changed. "
                                 "Not fetching.")
                     return self.extract_files(tmp_filename)


### PR DESCRIPTION
- update: allow index "checksum" value to be a url
- github-ci: fix pytest on MacOS
