### PR TITLE
conf: use correct configuration files - v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,30 +166,6 @@ jobs:
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  ubuntu-1604:
-    name: Ubuntu 16.04
-    runs-on: ubuntu-latest
-    container: ubuntu:16.04
-    steps:
-      - run: apt update
-      - run: |
-          apt -y install \
-            python-pytest \
-            python-yaml \
-            python3-pytest \
-            python3-yaml
-      - uses: actions/checkout@v1
-
-      - name: Python 2 unit tests
-        run: PYTHONPATH=. py.test
-      - name: Python 2 integration tests
-        run: PYTHONPATH=. python2 ./tests/integration_tests.py
-
-      - name: Python 3 unit tests
-        run: PYTHONPATH=. py.test-3
-      - name: Python 3 integration tests
-        run: PYTHONPATH=. python3 ./tests/integration_tests.py
-
   debian-10:
     name: Debian 10
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,34 +166,44 @@ jobs:
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  debian-10:
-    name: Debian 10
+  debian-12:
+    name: Debian 12
     runs-on: ubuntu-latest
-    container: debian:10
+    container: debian:12
     steps:
       - run: apt update
       - run: |
           apt -y install \
-            python-pytest \
-            python-yaml \
             python3-pytest \
             python3-yaml
       - uses: actions/checkout@v1
-
-      - name: Python 2 unit tests
-        run: PYTHONPATH=. pytest
-      - name: Python 2 integration tests
-        run: PYTHONPATH=. python2 ./tests/integration_tests.py
 
       - name: Python 3 unit tests
         run: PYTHONPATH=. pytest-3
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  debian-9:
-    name: Debian 9
+  debian-11:
+    name: Debian 11
     runs-on: ubuntu-latest
-    container: debian:9
+    container: debian:11
+    steps:
+      - run: apt update
+      - run: |
+          apt -y install \
+            python3-pytest \
+            python3-yaml
+      - uses: actions/checkout@v1
+
+      - name: Python 3 unit tests
+        run: PYTHONPATH=. pytest-3
+      - name: Python 3 integration tests
+        run: PYTHONPATH=. python3 ./tests/integration_tests.py
+
+  debian-10:
+    name: Debian 10
+    runs-on: ubuntu-latest
+    container: debian:10
     steps:
       - run: apt update
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,10 +70,10 @@ jobs:
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  fedora-36:
-    name: Fedora 36
+  fedora-38:
+    name: Fedora 38
     runs-on: ubuntu-latest
-    container: fedora:36
+    container: fedora:38
     steps:
       - run: |
           dnf -y install \
@@ -86,18 +86,17 @@ jobs:
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  fedora-35:
-    name: Fedora 35
+  fedora-37:
+    name: Fedora 37
     runs-on: ubuntu-latest
-    container: fedora:35
+    container: fedora:37
     steps:
       - run: |
-          yum -y install \
+          dnf -y install \
             python3 \
             python3-pytest \
             python3-pyyaml
       - uses: actions/checkout@v2
-
       - name: Python 3 unit tests
         run: PYTHONPATH=. pytest-3
       - name: Python 3 integration tests

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1135,27 +1135,39 @@ def _main():
 
     # Load user provided disable filters.
     disable_conf_filename = config.get("disable-conf")
-    if disable_conf_filename and os.path.exists(disable_conf_filename):
-        logger.info("Loading %s.", disable_conf_filename)
-        disable_matchers += load_matchers(disable_conf_filename)
+    if disable_conf_filename:
+        if os.path.exists(disable_conf_filename):
+            logger.info("Loading %s.", disable_conf_filename)
+            disable_matchers += load_matchers(disable_conf_filename)
+        else:
+            logger.warn("disable-conf file does not exist: {}".format(disable_conf_filename))
 
     # Load user provided enable filters.
     enable_conf_filename = config.get("enable-conf")
-    if enable_conf_filename and os.path.exists(enable_conf_filename):
-        logger.info("Loading %s.", enable_conf_filename)
-        enable_matchers += load_matchers(enable_conf_filename)
+    if enable_conf_filename:
+        if os.path.exists(enable_conf_filename):
+            logger.info("Loading %s.", enable_conf_filename)
+            enable_matchers += load_matchers(enable_conf_filename)
+        else:
+            logger.warn("enable-conf file does not exist: {}".format(enable_conf_filename))
 
     # Load user provided modify filters.
     modify_conf_filename = config.get("modify-conf")
-    if modify_conf_filename and os.path.exists(modify_conf_filename):
-        logger.info("Loading %s.", modify_conf_filename)
-        modify_filters += load_filters(modify_conf_filename)
+    if modify_conf_filename:
+        if os.path.exists(modify_conf_filename):
+            logger.info("Loading %s.", modify_conf_filename)
+            modify_filters += load_filters(modify_conf_filename)
+        else:
+            logger.warn("modify-conf file does not exist: {}".format(modify_conf_filename))
 
     # Load user provided drop filters.
     drop_conf_filename = config.get("drop-conf")
-    if drop_conf_filename and os.path.exists(drop_conf_filename):
-        logger.info("Loading %s.", drop_conf_filename)
-        drop_filters += load_drop_filters(drop_conf_filename)
+    if drop_conf_filename:
+        if os.path.exists(drop_conf_filename):
+            logger.info("Loading %s.", drop_conf_filename)
+            drop_filters += load_drop_filters(drop_conf_filename)
+        else:
+            logger.warn("drop-conf file does not exist: {}".format(drop_conf_filename))
 
     # Load the Suricata configuration if we can.
     suriconf = None


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/6172

If /etc/suricata/update.yaml specific a "disable-conf" of
"/some/path/to/dummy.conf", but /etc/suricata/disable.conf existed, it prefered
the existence of the file over the user specific one. This did not affect
command line parameters.

Now when looking for the default files, only override the configuration file
values if they are not present in the configuration file. This retains the
default behaviour of auto-finding the files, but respects the configuration
over auto-finding.

This also allows us to display an error if a specified configuration file does
not exist.
