### PR TITLE
matching: multi match support

### DIFF
--- a/doc/update.rst
+++ b/doc/update.rst
@@ -259,6 +259,15 @@ with the provided metadata::
           convert rules to drop. It is not available for rule
           modification.
 
+Multi Matching
+--------------
+
+The above matching methods can also be combined. It's logical AND, so all combined matcher need to match a given rule::
+
+  multi:filename:*/emerging-scan.rule;re:nmap;
+  multi:group:emerging-web_specific_apps;re:wordpress;re:cve[-,]201[6-9];
+  multi:re:cve[-_]202[23];metadata: deployment perimeter;
+
 Modifying Rules
 ---------------
 

--- a/suricata/update/configs/disable.conf
+++ b/suricata/update/configs/disable.conf
@@ -17,3 +17,7 @@
 # Disable all rules with a metadata of "deployment perimeter". Note that metadata
 # matches are case insensitive.
 # metadata: deployment perimeter
+
+# Example of multi matching
+# Disable all rules with significant performance impact (metadata match) from emerging-policy (group match)
+multi:metadata: performance_impact Significant;group:emerging-policy;

--- a/suricata/update/configs/drop.conf
+++ b/suricata/update/configs/drop.conf
@@ -9,3 +9,7 @@
 #
 # re:heartbleed
 # re:MS(0[7-9]|10)-\d+
+
+# Example of multi matching
+# Set phishing related (metadata match) rules from emerging-current_events (group match) to drop
+multi:metadata: tag Phishing;group:emerging-current_events;

--- a/suricata/update/configs/enable.conf
+++ b/suricata/update/configs/enable.conf
@@ -17,3 +17,7 @@
 # Enable all rules with a metadata of "deployment perimeter". Note that metadata
 # matches are case insensitive.
 # metadata: deployment perimeter
+
+# Example of multi matching
+# Enable all rules with a recent cve reference (regular expression match) and a perimeter deployment (metadata match)
+multi:re:cve[-_]202[23];metadata: deployment perimeter;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

This is an implementation of  [redmine 2509](https://redmine.openinfosecfoundation.org/issues/2509)

Describe changes:

This is a resubmit of pr #37. After reworking to fit the 2023 code base.

It adds support to specify multiple conditions to match a rule.

Syntax:
`multi:<match_condition1>;<match_condition2>;...<match_conditionN>;`

Examples:
Match all rules including the term "nmap" but just from the "emerging-scan.rules" file.
`multi:filename:rule/emerging-scan.rules; re:nmap;`

Match all rules with a recent cve reference and a perimeter deployment
`multi:re:cve-202[23];metadata: deployment perimeter;`
