### PR TITLE
Lua file handler

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -97,7 +97,7 @@ DEFAULT_OUTPUT_RULE_FILENAME = "suricata.rules"
 INDEX_EXPIRATION_TIME = 60 * 60 * 24 * 14
 
 # Rule keywords that come with files
-file_kw = ["filemd5", "filesha1", "filesha256", "dataset"]
+file_kw = ["filemd5", "filesha1", "filesha256", "dataset", "lua", "luajit"]
 
 def strict_error(msg):
     logger.error(msg)
@@ -562,6 +562,8 @@ def write_merged(filename, rulemap, dep_files):
                 if kw in rule:
                     if "dataset" == kw:
                         reformatted = handle_dataset_files(rule, dep_files)
+                    elif kw in ["lua", "luajit"]:
+                        handle_lua_rule_files(rule, dep_files, kw)
                     else:
                         handle_filehash_files(rule, dep_files, kw)
             if reformatted:
@@ -623,6 +625,8 @@ def write_to_directory(directory, files, rulemap, dep_files):
                         if kw in rule:
                             if "dataset" == kw:
                                 reformatted = handle_dataset_files(rulemap[rule.id], dep_files)
+                            elif kw in ["lua", "luajit"]:
+                                handle_lua_rule_files(rulemap[rule.id], dep_files, kw)
                             else:
                                 handle_filehash_files(rulemap[rule.id], dep_files, kw)
                     if reformatted:

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -499,6 +499,28 @@ def handle_filehash_files(rule, dep_files, fhash):
     else:
         logger.error("{} file {} was not found".format(fhash, filehash_fname))
 
+def handle_lua_rule_files(rule, dep_files, kw):
+    if not rule.enabled:
+        return
+    lua_rule_fname = rule.get(kw)
+    filename = [fname for fname, content in dep_files.items() if fname == lua_rule_fname]
+    if filename:
+        logger.debug("Copying lua file %s to output directory" % (lua_rule_fname))
+        filepath = os.path.join(config.get_state_dir(), "rules", os.path.dirname(filename[0]))
+        logger.debug("filepath: %s" % filepath)
+        try:
+            os.makedirs(filepath)
+        except OSError as oserr:
+            if oserr.errno != errno.EEXIST:
+                logger.error(oserr)
+                sys.exit(1)
+        logger.debug("output fname: %s" % os.path.join(filepath, os.path.basename(lua_rule_fname)))
+        with open(os.path.join(filepath, os.path.basename(lua_rule_fname)), "w+") as fp:
+            fp.write(dep_files[lua_rule_fname].decode("utf-8"))
+    else:
+        logger.error("lua file {} was not found".format(lua_rule_fname))
+
+
 def write_merged(filename, rulemap, dep_files):
 
     if not args.quiet:


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x ] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:https://redmine.openinfosecfoundation.org/issues/6395

Describe changes:
I added the function handle_lua_rule_files, which obviously handles lua files shipped within a rule tarball.
It works nearly exactly the same as the existing functions handle_filehash_files and handle_dataset_files.
testing was done for nested and non nested archives, and for single and multiple occurances of  lua and luajit keywords  in rules.
It assumes the final outputdir is called "rules", but handle_filehash_files does the same, so this wont break setups not already broken.