### PR TITLE
github: update links in the PR template - v1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,9 @@ Make sure these boxes are signed before submitting your Pull Request
 -- thank you.
 
 - [ ] I have read the contributing guide lines at
-  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
+  https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
 - [ ] I have signed the Open Information Security Foundation
-  contribution agreement at
-  https://suricata-ids.org/about/contribution-agreement/
+  contribution agreement at https://suricata.io/about/contribution-agreement/
 - [ ] I have updated the user guide (in doc/userguide/) to reflect the
   changes made (if applicable)
 


### PR DESCRIPTION
When I was checking a PR by another contributor, I noticed that the links were still pointing to Redmine and suricata-ids.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
none

Describe changes:
- replace redmine link to contribution guidelines with devguide one
- replace suricata-ids CLA with suricata.io one