### PR TITLE
update min-version required

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -120,7 +120,7 @@ This command will:
   and do not need to exist.
 
 * Download the Emerging Threats Open ruleset for your version of
-  Suricata, defaulting to 4.0.0 if not found.
+  Suricata, defaulting to 6.0.0 if not found.
 
 * Apply enable, disable, drop and modify filters as loaded above.
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -88,7 +88,7 @@ else:
     logger = logging.getLogger()
 
 # If Suricata is not found, default to this version.
-DEFAULT_SURICATA_VERSION = "4.0.0"
+DEFAULT_SURICATA_VERSION = "6.0.0"
 
 # The default filename to use for the output rule file. This is a
 # single file concatenating all input rule files together.


### PR DESCRIPTION
Jason, who are the consumers of `min-version` keys? https://github.com/OISF/suricata-intel-index/blob/master/index.yaml#L59
Do we always know that these external sources do support the said min-versions even now?