### PR TITLE
Match SSLBL license to their website.

### DIFF
--- a/suricata/update/data/index.py
+++ b/suricata/update/data/index.py
@@ -205,7 +205,7 @@ index = {   'sources': {   'et/open': {   'description': 'Proofpoint ET Open is 
                                                                 'the JA3 '
                                                                 'fingerprint '
                                                                 'ruleset.\n',
-                                                 'license': 'Non-Commercial',
+                                                 'license': 'CC0',
                                                  'min-version': '4.1.0',
                                                  'summary': 'Abuse.ch Suricata '
                                                             'JA3 Fingerprint '
@@ -244,7 +244,7 @@ index = {   'sources': {   'et/open': {   'description': 'Proofpoint ET Open is 
                                                                 'communication '
                                                                 'on the TCP '
                                                                 'layer.\n',
-                                                 'license': 'Non-Commercial',
+                                                 'license': 'CC0',
                                                  'summary': 'Abuse.ch SSL '
                                                             'Blacklist',
                                                  'url': 'https://sslbl.abuse.ch/blacklist/sslblacklist.rules',


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request
-- thank you.

- [x] I have read the contributing guide lines at
  https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation
  contribution agreement at
  https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Updates the license of two entries, each for SSLBL project lists, to match the license displayed on [their website](https://sslbl.abuse.ch/blacklist/#tos). The current license statement, 'Non-Commercial', does not match their [Terms of Services](https://sslbl.abuse.ch/blacklist/#tos), which states:

> Terms of Services (ToS)
>
> By using the website of SSLBL, or any of the services / datasets referenced above, you agree that:
>
>    All datasets offered by SSLBL can be used for both, commercial and non-commercial purpose without any limitations (CC0)
>    Any data offered by SSLBL is served as it is on best effort
>    SSLBL can not be held liable for any false positive or damage caused by the use of the website or the datasets offered above

