### PR TITLE
fetch: handle bare file urls not ending in .rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   https://redmine.openinfosecfoundation.org/issues/6777
 - If no Suricata is found, Suricata-Update will assume version 6.0.0
   instead of 4.0.0.
+- Handle URLs of bare files that don't end in .rules:
+  https://redmine.openinfosecfoundation.org/issues/3664
 
 ## 1.3.0 - 2023-07-07
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -235,6 +235,8 @@ class Fetch:
 
         # The file is not an archive, treat it as an individual file.
         basename = os.path.basename(filename).split("-", 1)[1]
+        if not basename.endswith(".rules"):
+            basename = "{}.rules".format(basename)
         files = {}
         files[basename] = open(filename, "rb").read()
         return files


### PR DESCRIPTION
If a URL is a bare file, and does not end in .rules, Suricata-Update will ignore it.  Such URLs might look like:

- https://<misp>/1011

Tested with https://codemonkey.net/tmp/1011

Ticket: https://redmine.openinfosecfoundation.org/issues/3664