### PR TITLE
fix: properly handle directories for local files

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -302,7 +302,7 @@ def load_local(local, files):
         for dirpath, dirnames, filenames in os.walk(local):
             for filename in filenames:
                 if filename.endswith(".rules"):
-                    path = os.path.join(local, filename)
+                    path = os.path.join(dirpath, filename)
                     load_local(path, files)
     else:
         local_files = glob.glob(local)


### PR DESCRIPTION
When loading local files and rule files are nested in a folder, the current behavior prepends the base path and not the nested path which results in a file not found error. This change updates this to use the `dirpath` parameter from `os.walk` so that it is handled correctly.

Given a structure of
  /tmp/rules/
  ├── file1.rules
  └── nested
      └── file2.rules

Today it would try to load this as the following
* /tmp/rules/file1.rules
* /tmp/rules/file2.rules

With the fix this would be
* /tmp/rules/file1.rules
* /tmp/rules/nested/file2.rules

https://redmine.openinfosecfoundation.org/issues/7370