### PR TITLE
matching: use a set match for SIDs instead of an array - v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,10 @@ jobs:
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  fedora-39:
-    name: Fedora 39
+  fedora-41:
+    name: Fedora 41
     runs-on: ubuntu-latest
-    container: fedora:39
+    container: fedora:41
     steps:
       - run: |
           dnf -y install \
@@ -68,17 +68,17 @@ jobs:
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  fedora-38:
-    name: Fedora 38
+  fedora-40:
+    name: Fedora 40
     runs-on: ubuntu-latest
-    container: fedora:38
+    container: fedora:40
     steps:
       - run: |
           dnf -y install \
             python3 \
             python3-pytest \
             python3-pyyaml
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Python 3 unit tests
         run: PYTHONPATH=. pytest-3
       - name: Python 3 integration tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -211,8 +211,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - run: brew install python
-      - run: pip3 install PyYAML
-      - run: pip3 install pytest
+      - run: brew install pytest
       - uses: actions/checkout@v1
-      - run: PYTHONPATH=. python3 -m pytest
-      - run: PYTHONPATH=. python3 ./tests/integration_tests.py
+      - name: Create Python virtual environment
+        run: python3 -m venv ./testenv
+      - name: Install PyYAML
+        run: |
+          . ./testenv/bin/activate
+          pip install pyyaml
+      - run: |
+          . ./testenv/bin/activate
+          PYTHONPATH=. pytest
+      - run: |
+          . ./testenv/bin/activate
+          PYTHONPATH=. python3 ./tests/integration_tests.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,30 +52,6 @@ jobs:
       - name: Python 3 integration tests
         run: PYTHONPATH=. python3 ./tests/integration_tests.py
 
-  centos-7:
-    name: CentOS 7
-    runs-on: ubuntu-latest
-    container: centos:7
-    steps:
-      - run: yum -y install epel-release
-      - run: |
-          yum -y install \
-            python2-pytest \
-            python2-pyyaml \
-            python36-pytest \
-            python36-yaml
-      - uses: actions/checkout@v1
-
-      - name: Python 2 unit tests
-        run: PYTHONPATH=. py.test-2.7
-      - name: Python 2 integration tests
-        run: PYTHONPATH=. python2 ./tests/integration_tests.py
-
-      - name: Python 3 unit tests
-        run: PYTHONPATH=. py.test-3
-      - name: Python 3 integration tests
-        run: PYTHONPATH=. python3 ./tests/integration_tests.py
-
   fedora-39:
     name: Fedora 39
     runs-on: ubuntu-latest

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -278,6 +278,8 @@ def load_drop_filters(filename):
 def parse_matchers(fileobj):
     matchers = []
 
+    id_set_matcher = matchers_mod.IdSetRuleMatcher()
+
     for line in fileobj:
         line = line.strip()
         if not line or line.startswith("#"):
@@ -287,9 +289,18 @@ def parse_matchers(fileobj):
         if not matcher:
             logger.warn("Failed to parse: \"%s\"" % (line))
         else:
-            matchers.append(matcher)
+            # If matcher is an IdRuleMatcher
+            if isinstance(matcher, matchers_mod.IdRuleMatcher):
+                for (gid, sid) in matcher.signatureIds:
+                    id_set_matcher.add(gid, sid)
+            else:
+                matchers.append(matcher)
+
+    if len(id_set_matcher.sids) > 0:
+        matchers.append(id_set_matcher)
 
     return matchers
+
 
 def load_matchers(filename):
     with open(filename) as fileobj:

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -51,6 +51,25 @@ class ProtoRuleMatcher:
         return rule.proto == self.proto
 
 
+class IdSetRuleMatcher(object):
+    """Matcher object that matches on a set of rule SIDs.
+
+    This matcher is not directly parsed, but instead constructed after
+    loading individual IdRuleMatchers and consolidated into one
+    matcher that is much faster.
+
+    """
+    def __init__(self):
+        self.sids = {}
+
+    def add(self, generatorId, signatureId):
+        self.sids[(generatorId, signatureId)] = True
+
+    def match(self, rule):
+        key = (rule.gid, rule.sid)
+        return key in self.sids
+
+
 class IdRuleMatcher(object):
     """Matcher object to match an idstools rule object by its signature
     ID."""

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -66,7 +66,7 @@ re:.# This is a comment*
         self.assertEqual(
             matchers[1].__class__, matchers_mod.ReRuleMatcher)
         self.assertEqual(
-            matchers[2].__class__, matchers_mod.IdRuleMatcher)
+            matchers[2].__class__, matchers_mod.IdSetRuleMatcher)
 
 class IdRuleMatcherTestCase(unittest.TestCase):
 


### PR DESCRIPTION
- **matching: consolidate sid matchers into a set matcher**
  Consolidate SID matchers into a single SID set matcher which stores a
  dict of all SIDs to be matched. An array of many SID matchers to a
  single matcher with much faster lookup.
  
  This can reduce a many minute runtime down to 10s of seconds.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7415
  

- **github-ci: remove centos-7 build, EOL**
  

- **github-ci: add fedora 40, 41; remove 38, 39**
  

- **github-ci: run macos python jobs in virtualenv**
  With the latest brew changes, a virtualenv is required to install
  pyyaml.
  