### PR TITLE
engine: Replace method to split suricata config

### DIFF
--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -108,8 +108,8 @@ class Configuration:
         conf = {}
         for line in configuration_dump.splitlines():
             try:
-                key, val = line.decode().split(" = ")
-                conf[key] = val
+                parsed_line = re.match(r'(.*?) = (.*)', line.decode())
+                conf[parsed_line.group(1)] = parsed_line.group(2)
             except:
                 logger.warning("Failed to parse: %s", line)
         build_info = get_build_info(suricata_path)


### PR DESCRIPTION
This PR changes the way suricata-update splits suricata config options that are read in via `suricata --dump-config`. This allows for values (such as BPF filters) to contain equal signs (`=`), while not impacting any other configuration parameters. Right now, `suricata-update` is throwing a warning log message if this is the case.

Please let me now if there is anything else you need. As stated in the ticket, I can add unit tests if necessary - there are none yet for engine.py.


- [X] I have read the contributing guide lines at
  https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation
  contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the
  changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [Link](https://redmine.openinfosecfoundation.org/issues/7637)
