### PR TITLE
fixups/v1

### DIFF
--- a/suricata/update/configs/disable.conf
+++ b/suricata/update/configs/disable.conf
@@ -4,6 +4,10 @@
 # 1:2019401
 # 2019401
 
+# A rule revision can also be provided, but the GID must also be
+# specified.
+#1:3321408:2
+
 # Example of disabling a rule by regular expression.
 # - All regular expression matches are case insensitive.
 # re:heartbleed

--- a/suricata/update/configs/enable.conf
+++ b/suricata/update/configs/enable.conf
@@ -4,6 +4,10 @@
 # 1:2019401
 # 2019401
 
+# A rule revision can also be provided, but the GID must also be
+# specified.
+#1:3321408:2
+
 # Example of enabling a rule by regular expression.
 # - All regular expression matches are case insensitive.
 # re:heartbleed

--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -109,7 +109,7 @@ class Configuration:
         conf = {}
         for line in configuration_dump.splitlines():
             try:
-                key, val = line.decode().split(" = ")
+                key, val = line.decode().split(" = ", maxsplit=1)
                 conf[key] = val
             except:
                 logger.warning("Failed to parse: %s", line)

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1409,7 +1409,8 @@ def _main():
             else:
                 logger.info("Reload command returned: {}".format(output.decode("utf-8")))
         except Exception as err:
-            logger.error("Reload command failed: {}".format(err.output))
+            logger.error("Reload command failed: {}".format(
+                getattr(err, 'output', str(err))))
 
     logger.info("Done.")
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1399,10 +1399,17 @@ def _main():
         return 1
 
     if not config.args().no_reload and config.get("reload-command"):
-        logger.info("Running %s." % (config.get("reload-command")))
-        rc = subprocess.Popen(config.get("reload-command"), shell=True).wait()
-        if rc != 0:
-            logger.error("Reload command exited with error: {}".format(rc))
+        reload_command = config.get("reload-command")
+        logger.info("Running {}.".format(reload_command))
+        try:
+            output = subprocess.check_output(
+                reload_command, shell=True, stderr=subprocess.STDOUT)
+            if reload_command.find("suricatasc") > -1 and output.decode("utf-8").find("NOK") > -1:
+                logger.error("Reload command was not successful: {}".format(output))
+            else:
+                logger.info("Reload command returned: {}".format(output.decode("utf-8")))
+        except Exception as err:
+            logger.error("Reload command failed: {}".format(err.output))
 
     logger.info("Done.")
 

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -290,8 +290,15 @@ def parse_matchers(fileobj):
         else:
             # If matcher is an IdRuleMatcher
             if isinstance(matcher, matchers_mod.IdRuleMatcher):
-                for (gid, sid) in matcher.signatureIds:
-                    id_set_matcher.add(gid, sid)
+                for sig in matcher.signatureIds:
+                    if len(sig) == 2:
+                        # The "set" matcher only supports gid:sid.
+                        id_set_matcher.add(sig[0], sig[1])
+                    elif len(sig) == 3:
+                        # This must also have a rev, don't add to set,
+                        # but add as its own IdSetRuleMatcher.
+                        matchers.append(
+                            matchers_mod.IdRuleMatcher(sig[0], sig[1], sig[2]))
             else:
                 matchers.append(matcher)
 

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -76,7 +76,7 @@ class IdRuleMatcher(object):
 
     def __init__(self, generatorId=None, signatureId=None, rev=None):
         self.signatureIds = []
-        if generatorId and signatureId and rev:
+        if generatorId and signatureId and rev is not None:
             self.signatureIds.append((generatorId, signatureId, rev))
         elif generatorId and signatureId:
             self.signatureIds.append((generatorId, signatureId))

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -220,7 +220,6 @@ class MetadataRuleMatch(object):
 
     @classmethod
     def parse(cls, buf):
-        print(buf)
         if buf.startswith("metadata:"):
             buf = buf.split(":", 1)[1].strip()
             parts = buf.split(" ", 1)

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -317,7 +317,7 @@ class AddMetadataFilter(object):
             raise Exception("metadata-add: invalid number of arguments")
         matcher = parse_rule_match(match_string)
         if not matcher:
-            raise Exception("Bad match string: %s" % (matchstring))
+            raise Exception("Bad match string: %s" % (match_string))
         return cls(matcher, key, val)
 
 

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -74,15 +74,21 @@ class IdRuleMatcher(object):
     """Matcher object to match an idstools rule object by its signature
     ID."""
 
-    def __init__(self, generatorId=None, signatureId=None):
+    def __init__(self, generatorId=None, signatureId=None, rev=None):
         self.signatureIds = []
-        if generatorId and signatureId:
+        if generatorId and signatureId and rev:
+            self.signatureIds.append((generatorId, signatureId, rev))
+        elif generatorId and signatureId:
             self.signatureIds.append((generatorId, signatureId))
 
     def match(self, rule):
-        for (generatorId, signatureId) in self.signatureIds:
-            if generatorId == rule.gid and signatureId == rule.sid:
-                return True
+        for sig in self.signatureIds:
+            if len(sig) == 3:
+                if sig[0] == rule.gid and sig[1] == rule.sid and sig[2] == rule.rev:
+                    return True
+            elif len(sig) == 2:
+                if sig[0] == rule.gid and sig[1] == rule.sid:
+                    return True
         return False
 
     @classmethod
@@ -92,7 +98,7 @@ class IdRuleMatcher(object):
         for entry in buf.split(","):
             entry = entry.strip()
 
-            parts = entry.split(":", 1)
+            parts = entry.split(":")
             if not parts:
                 return None
             if len(parts) == 1:
@@ -101,11 +107,19 @@ class IdRuleMatcher(object):
                     matcher.signatureIds.append((1, signatureId))
                 except:
                     return None
-            else:
+            elif len(parts) == 2:
                 try:
                     generatorId = int(parts[0])
                     signatureId = int(parts[1])
                     matcher.signatureIds.append((generatorId, signatureId))
+                except:
+                    return None
+            elif len(parts) == 3:
+                try:
+                    generatorId = int(parts[0])
+                    signatureId = int(parts[1])
+                    rev = int(parts[2])
+                    matcher.signatureIds.append((generatorId, signatureId, rev))
                 except:
                     return None
 

--- a/suricata/update/util.py
+++ b/suricata/update/util.py
@@ -30,10 +30,10 @@ def md5_hexdigest(buf):
 
     :returns: A string representing the hex value of the computed MD5.
     """
-    if sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 9):
-        return hashlib.md5(buf).hexdigest().strip()
-    else:
+    try:
         return hashlib.md5(buf, usedforsecurity=False).hexdigest().strip()
+    except:
+        return hashlib.md5(buf).hexdigest().strip()
 
 def mktempdir(delete_on_exit=True):
     """ Create a temporary directory that is removed on exit. """

--- a/suricata/update/version.py
+++ b/suricata/update/version.py
@@ -4,4 +4,4 @@
 # Alpha: 1.0.0a1
 # Development: 1.0.0dev0
 # Release candidate: 1.0.0rc1
-version = "1.3.4"
+version = "1.3.5dev0"

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -108,6 +108,13 @@ class IdRuleMatcherTestCase(unittest.TestCase):
         matcher = matchers_mod.IdRuleMatcher.parse("1:a")
         self.assertIsNone(matcher)
 
+    def test_parse_gid_sid_rev(self):
+        matcher = matchers_mod.IdRuleMatcher.parse("1:234:5")
+        self.assertIsNotNone(matcher)
+        self.assertEqual(1, len(matcher.signatureIds))
+        self.assertEqual(matcher.signatureIds[0], (1, 234, 5))
+
+
 class MetadataAddTestCase(unittest.TestCase):
 
     def test_metadata_add(self):

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -113,6 +113,7 @@ class IdRuleMatcherTestCase(unittest.TestCase):
         self.assertIsNotNone(matcher)
         self.assertEqual(1, len(matcher.signatureIds))
         self.assertEqual(matcher.signatureIds[0], (1, 234, 5))
+        self.assertNotEqual(matcher.signatureIds[0], (1, 234, 0))
 
 
 class MetadataAddTestCase(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, py39, py310, py311
+envlist = py27, py36, py37, py38, py39, py310, py311, py312, py313
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
- **version: 1.3.5dev0**
  

- **matchers: remove debug print**
  

- **engine: choose better Suricata logging levels for rule test**
  The current default is to use SC_LOG_LEVEL=warning which can output
  non-fatal warnings which is generally not what you want when running
  from cron with "suricata-update -q".
  
  Now, if "-q" is provided, run Suricata with SC_LOG_LEVEL=error which
  is useful for cron to ony be notified of fata errors. Generally
  end-users are not worried about rule warnings such as:
  
      ja3.hash should not be used together with nocase, since the rule
      is automatically lowercased anyway which makes nocase redundant.
  
  This also allows for log level be set with SC_LOG_LEVEL, in which case
  Suricata-Update  will not change the log level.
  
  Additionally, make Suricata more verbose if Suricata-Update is run
  with "-v".
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7494
  

- **fix: bad variable name in metadata matcher**
  

- **matching: allow a rule revision to be matched as well**
  A rule ID can now be matched with a revision given the following
  format of:
  
  <gid>:<sid>:<rev>
  
  The <gid> has to be specified for a revision match, as a specifier
  with 2 components is read as "gid" and "rev".
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7425
  

- **reload: if quiet, suppress rule reload output**
  If successful, and the quiet flag was provided, don't output the
  return from the suricatasc socket command, or whatever the rule reload
  command returns.
  
  If there was an error, the output will be logged as an error.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7494
  

- **tests: add tox tests for python 3.12 and 3.13**
  

- **cleanups: apply valid cleanups suggested by copilot**
  Add test for gid/sed/rev that shouldn't match.
  

- **md5: don't rely on version for usedforsecurity**
  The usedforsecurity flag to hashlib.md5 doesn't appear to be version
  specific, due to backporting, etc.
  
  Instead attempt to use it, on exception, fallback to not using it.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7255
  

- **config: handle suricata config with '=' in value**
  For example, when an '=' appears in the --dump-config output when its
  used as part of a bpf-filter.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7637
  