### PR TITLE
fixups/v2

### DIFF
--- a/suricata/update/engine.py
+++ b/suricata/update/engine.py
@@ -109,7 +109,7 @@ class Configuration:
         conf = {}
         for line in configuration_dump.splitlines():
             try:
-                key, val = line.decode().split(" = ")
+                key, val = line.decode().split(" = ", maxsplit=1)
                 conf[key] = val
             except:
                 logger.warning("Failed to parse: %s", line)

--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1409,7 +1409,8 @@ def _main():
             else:
                 logger.info("Reload command returned: {}".format(output.decode("utf-8")))
         except Exception as err:
-            logger.error("Reload command failed: {}".format(err.output))
+            logger.error("Reload command failed: {}".format(
+                getattr(err, 'output', str(err))))
 
     logger.info("Done.")
 

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -76,7 +76,7 @@ class IdRuleMatcher(object):
 
     def __init__(self, generatorId=None, signatureId=None, rev=None):
         self.signatureIds = []
-        if generatorId and signatureId and rev:
+        if generatorId and signatureId and rev is not None:
             self.signatureIds.append((generatorId, signatureId, rev))
         elif generatorId and signatureId:
             self.signatureIds.append((generatorId, signatureId))

--- a/suricata/update/util.py
+++ b/suricata/update/util.py
@@ -30,10 +30,10 @@ def md5_hexdigest(buf):
 
     :returns: A string representing the hex value of the computed MD5.
     """
-    if sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 9):
-        return hashlib.md5(buf).hexdigest().strip()
-    else:
+    try:
         return hashlib.md5(buf, usedforsecurity=False).hexdigest().strip()
+    except:
+        return hashlib.md5(buf).hexdigest().strip()
 
 def mktempdir(delete_on_exit=True):
     """ Create a temporary directory that is removed on exit. """

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -113,6 +113,7 @@ class IdRuleMatcherTestCase(unittest.TestCase):
         self.assertIsNotNone(matcher)
         self.assertEqual(1, len(matcher.signatureIds))
         self.assertEqual(matcher.signatureIds[0], (1, 234, 5))
+        self.assertNotEqual(matcher.signatureIds[0], (1, 234, 0))
 
 
 class MetadataAddTestCase(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, py39, py310, py311
+envlist = py27, py36, py37, py38, py39, py310, py311, py312, py313
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
- **tests: add tox tests for python 3.12 and 3.13**
  

- **cleanups: apply valid cleanups suggested by copilot**
  Add test for gid/sed/rev that shouldn't match.
  

- **md5: don't rely on version for usedforsecurity**
  The usedforsecurity flag to hashlib.md5 doesn't appear to be version
  specific, due to backporting, etc.
  
  Instead attempt to use it, on exception, fallback to not using it.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7255
  

- **config: handle suricata config with '=' in value**
  For example, when an '=' appears in the --dump-config output when its
  used as part of a bpf-filter.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7637
  