### PR TITLE
staging: 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.3.6 - 2025-07-02
+- Copy Lua scripts for rules over to output directory:
+  https://redmine.openinfosecfoundation.org/issues/6395
+- Fix parsing of nested lists in address and ports:
+  https://redmine.openinfosecfoundation.org/issues/7799
+
 ## 1.3.5 - 2025-06-06
 
 - Handle '=' in Suricata --dump-config:

--- a/suricata/update/rule.py
+++ b/suricata/update/rule.py
@@ -212,9 +212,16 @@ def parse(buf, group=None):
             if not rem:
                 return None
             if rem[0] == "[":
-                end = rem.find("]")
-                if end < 0:
-                    return
+                depth = 1
+                end = 0
+                while depth > 0:
+                    end += 1
+                    if end >= len(rem):
+                        return
+                    if rem[end] == "[":
+                        depth += 1
+                    elif rem[end] == "]":
+                        depth -= 1
                 end += 1
                 token = rem[:end].strip()
                 rem = rem[end:].strip()

--- a/suricata/update/version.py
+++ b/suricata/update/version.py
@@ -4,4 +4,4 @@
 # Alpha: 1.0.0a1
 # Development: 1.0.0dev0
 # Release candidate: 1.0.0rc1
-version = "1.3.5"
+version = "1.3.6"

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -254,3 +254,11 @@ alert dnp3 any any -> any any (msg:"SURICATA DNP3 Request flood detected"; \
         rule = suricata.update.rule.parse(rule_string)
         self.assertIsNotNone(rule)
         self.assertTrue("ja3" in rule["features"])
+
+    def test_parse_var_lists(self):
+        rule_string = u"""alert http [any,![$EXTERNAL_IP,$REVERSE_PROXY_HOSTS,$ODD_HTTP_HOSTS]] any -> [any,![$EXTERNAL_IP,$REVERSE_PROXY_HOSTS,$ODD_HTTP_HOSTS]] 80 (msg:"TEST Unknown var"; sid: 99000003; rev: 1;)"""
+        rule = suricata.update.rule.parse(rule_string)
+        self.assertEqual(rule["source_addr"], "[any,![$EXTERNAL_IP,$REVERSE_PROXY_HOSTS,$ODD_HTTP_HOSTS]]")
+        self.assertEqual(rule["source_port"], "any")
+        self.assertEqual(rule["dest_addr"], "[any,![$EXTERNAL_IP,$REVERSE_PROXY_HOSTS,$ODD_HTTP_HOSTS]]")
+        self.assertEqual(rule["dest_port"], "80")


### PR DESCRIPTION
- **lua: support lua rules**
  Add lua to the list of keywords that reference files and copy in place.
  
  Makes use of the filehash function, so make that function more generic
  for embedded files.
  
  Ticket: #6395
  

- **rules: fix parsing of address lists**
  The previous parser just looked for the next "]" to find the end of a
  list without respect for list depth. Instead step through the array
  tracking the depth of the nested lists.
  
  Ticket: #7799
  

- **version: 1.3.6**
  