### PR TITLE
doc: include list-enabled-sources in help output

### DIFF
--- a/suricata/update/parsers.py
+++ b/suricata/update/parsers.py
@@ -247,6 +247,7 @@ def parse_arg():
     update_parser.epilog = r"""other commands:
     update-sources             Update the source index
     list-sources               List available sources
+    list-enabled-sources       List enabled sources
     enable-source              Enable a source from the index
     disable-source             Disable an enabled source
     remove-source              Remove an enabled or disabled source


### PR DESCRIPTION
Ticket: #7800

Addresses a minor Debian bug report (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1108723)

- [X] I have read the contributing guide lines at
  https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation
  contribution agreement at https://suricata.io/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/7800

Describe changes:
- Include `list-enabled-sources` in help output.
