### PR TITLE
20251001/staging/v1

### DIFF
--- a/suricata/update/main.py
+++ b/suricata/update/main.py
@@ -1304,8 +1304,10 @@ def _main():
 
         for fltr in modify_filters:
             if fltr.match(rule):
-                rule = fltr.run(rule)
-                modified = True
+                new_rule = fltr.run(rule)
+                if new_rule != rule:
+                    rule = new_rule
+                    modified = True
 
         if enabled:
             enable_count += 1

--- a/suricata/update/matchers.py
+++ b/suricata/update/matchers.py
@@ -101,6 +101,14 @@ class IdRuleMatcher(object):
             parts = entry.split(":")
             if not parts:
                 return None
+
+            # The first part musth parse as a number, if not, its
+            # not a signature ID expression.
+            try:
+                int(parts[0])
+            except:
+                return None
+
             if len(parts) == 1:
                 try:
                     signatureId = int(parts[0])
@@ -122,6 +130,10 @@ class IdRuleMatcher(object):
                     matcher.signatureIds.append((generatorId, signatureId, rev))
                 except:
                     return None
+
+        # If no valid signature IDs were parsed, return None
+        if not matcher.signatureIds:
+            return None
 
         return matcher
 

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -141,3 +141,13 @@ class MetadataMatchTestCase(unittest.TestCase):
         metadata_filter = matchers_mod.MetadataRuleMatch.parse(filter_string)
         self.assertIsNotNone(metadata_filter)
         self.assertTrue(metadata_filter.match(rule))
+
+class ReRuleMatcherTestCase(unittest.TestCase):
+
+    def test_parse_enable_conf_expression(self):
+        """Test regular expression matcher with multiple ':'.
+        Ticket: https://redmine.openinfosecfoundation.org/issues/7922
+        """
+        expression = r're:^.+\(msg:\"(ET|ETPRO)\s+(CURRENT|MALWARE|MOBILE_MALWARE|TROJAN|CNC|ACTIVEX|WORM|NETBIOS|USER_AGENTS).+\s+sid:\s?(?!(2026850|2809199);).*$'
+        matcher = matchers_mod.parse_rule_match(expression)
+        self.assertEqual(matcher.__class__, matchers_mod.ReRuleMatcher)

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38
+envlist = py27, py36, py37, py38, py39, py310, py311, py312, py313
 
 [testenv]
 commands = python ./tests/integration_tests.py


### PR DESCRIPTION
- **matchers: fix regular expression matching**
  A regular express with multiple ':' was accidentally being parsed as an
  ID matcher. Making ID matching more strict.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7922
  

- **misc: count number of rules that were actually modified**
  And not all that are just subject to modification.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7967
  

- **tox: update versions for integration tests**
  